### PR TITLE
Update container workflow & fix img tagging

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -16,22 +16,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Login to cr
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # adds short sha tag (e.g. sha-123abc)
+            type=sha
+            # adds release ref tag as-is (e.g. v1.2.3)
+            type=ref,event=tag
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ github.event.release.tag_name || github.sha }}


### PR DESCRIPTION
Will now (correctly) build and tag container image under following conditions:
1. push to main: gets tagged as `sha-123abc`
2. published release: gets tagged as release tag ref