### PR TITLE
[bugfix] prevent double args printed for flags

### DIFF
--- a/internal/ssh/handler.go
+++ b/internal/ssh/handler.go
@@ -158,7 +158,6 @@ func (h *SessionHandler) DeleteFile(sesh *UserSession, file *snips.File) {
 	if err := flags.Parse(sesh.Stderr(), args); err != nil {
 		if !errors.Is(err, flag.ErrHelp) {
 			log.Warn().Err(err).Msg("invalid user specified flags")
-			flags.PrintDefaults()
 		}
 		return
 	}
@@ -264,7 +263,6 @@ func (h *SessionHandler) Upload(sesh *UserSession) {
 	if err := flags.Parse(sesh.Stderr(), sesh.Command()); err != nil {
 		if !errors.Is(err, flag.ErrHelp) {
 			log.Warn().Err(err).Msg("invalid user specified flags")
-			flags.PrintDefaults()
 		}
 		return
 	}


### PR DESCRIPTION
🤷 oops

<img width="590" alt="image" src="https://user-images.githubusercontent.com/16991201/233867030-a9df8d39-94a2-4e9f-b559-7afefc3d195b.png">


s/o @ygelfand for finding it