### PR TITLE
Fix flickering scroll bug on mobile

### DIFF
--- a/web/static/css/index.css
+++ b/web/static/css/index.css
@@ -219,3 +219,9 @@ a:hover {
 .muted {
   color: var(--color-gray-6);
 }
+
+@media (max-width: 768px) {
+  .container {
+    padding: 0 0.5rem;
+  }
+}

--- a/web/static/js/snips.js
+++ b/web/static/js/snips.js
@@ -76,29 +76,34 @@ const watchForShiftClick = () => {
   });
 };
 
-// setToTopButton hides the "to top" button when the top of the page is visible, and shows it when it's not.
-const setToTopButton = () => {
+// initHeaderObserver will hide the "to top" button when the top of the page is visible, and shows it when it's not.
+const initHeaderObserver = () => {
   const element = document.querySelector("#to-top");
   if (!element) return;
 
-  const parent = element.parentElement;
-  if (!parent) return;
+  const nav = element.closest("nav");
+  if (!nav) return;
 
-  const { top } = parent.getBoundingClientRect();
+  const observer = new IntersectionObserver(
+    ([entry]) => {
+      if (!entry.isIntersecting) {
+        element.removeAttribute("data-hide");
+      } else {
+        element.setAttribute("data-hide", "");
+      }
+    },
+    // https://stackoverflow.com/a/61115077
+    { rootMargin: "-1px 0px 0px 0px", threshold: [1] }
+  );
 
-  if (top === 0) {
-    element.removeAttribute("data-hide");
-  } else {
-    element.setAttribute("data-hide", "");
-  }
+  observer.observe(nav);
 };
 
-window.addEventListener("scroll", setToTopButton);
 window.addEventListener("hashchange", highlightLines);
 window.addEventListener("DOMContentLoaded", async () => {
+  initHeaderObserver();
   watchForShiftClick();
   highlightLines();
-  setToTopButton();
 
   mermaid.initialize({ startOnLoad: false, theme: "dark" });
   await mermaid.run({

--- a/web/templates/file.go.html
+++ b/web/templates/file.go.html
@@ -16,7 +16,7 @@
   <div class="stripes"></div>
   <div class="container">
     <h1 class="title"><a href="/">snips<span class="sh">.sh</span></a></h1>
-    <div class="file-header">
+    <nav class="file-header">
       <div class="file-details">
         file: <a href="#">{{ .FileID }}</a>
         ({{ .FileType }}) &middot; {{ .FileSize }}
@@ -27,10 +27,10 @@
       {{ if .RawHREF }}
       <a class="file-header-link" href="{{ .RawHREF }}" aria-label="view raw file">view raw</a>
       {{ end }}
-    </div>
-    <div class="file-content">
+    </nav>
+    <article class="file-content">
       {{ .HTML }}
-    </div>
+    </article>
   </div>
   <footer class="file-footer muted">
     <div style="margin-bottom:0.75rem;">


### PR DESCRIPTION
Closes:
- #23 

Instead of listening on a scroll event, use an [intersection observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API). It's much more performant and avoids the jittering and unnecessary (not debounced) events of a scroll listener.

Also added a media query to relax the container padding on small screens. 


https://github.com/robherley/snips.sh/assets/16991201/0fe3af6a-e879-4b9c-ad7b-2cf6064f7092

