### PR TITLE
Gracefully quit ssh session, make the max duration configurable

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -37,19 +37,21 @@ docker run ghcr.io/robherley/snips.sh -usage
 ```
 
 ```
-KEY                        TYPE              DEFAULT                DESCRIPTION
-SNIPS_DEBUG                True or False     False                  enable debug logging and pprof
-SNIPS_ENABLEGUESSER        True or False     True                   enable guesslang model to detect file types
-SNIPS_HMACKEY              String            hmac-and-cheese        symmetric key used to sign URLs
-SNIPS_LIMITS_FILESIZE      Unsigned Integer  1048576                maximum file size in bytes
-SNIPS_LIMITS_FILESPERUSER  Unsigned Integer  100                    maximum number of files per user
-SNIPS_DB_FILEPATH          String            data/snips.db          path to database file
-SNIPS_HTTP_INTERNAL        URL               http://localhost:8080  internal address to listen for http requests
-SNIPS_HTTP_EXTERNAL        URL               http://localhost:8080  external http address displayed in commands
-SNIPS_SSH_INTERNAL         URL               ssh://localhost:2222   internal address to listen for ssh requests
-SNIPS_SSH_EXTERNAL         URL               ssh://localhost:2222   external ssh address displayed in commands
-SNIPS_SSH_HOSTKEYPATH      String            data/keys/snips        path to host keys (without extension)
-SNIPS_METRICS_STATSD       URL                                      statsd server address (e.g. udp://localhost:8125)
+KEY                           TYPE              DEFAULT                DESCRIPTION
+SNIPS_DEBUG                   True or False     False                  enable debug logging and pprof
+SNIPS_ENABLEGUESSER           True or False     True                   enable guesslang model to detect file types
+SNIPS_HMACKEY                 String            hmac-and-cheese        symmetric key used to sign URLs
+SNIPS_LIMITS_FILESIZE         Unsigned Integer  1048576                maximum file size in bytes
+SNIPS_LIMITS_FILESPERUSER     Unsigned Integer  100                    maximum number of files per user
+SNIPS_LIMITS_SESSIONDURATION  Duration          15m                    maximum ssh session duration
+SNIPS_DB_FILEPATH             String            data/snips.db          path to database file
+SNIPS_HTTP_INTERNAL           URL               http://localhost:8080  internal address to listen for http requests
+SNIPS_HTTP_EXTERNAL           URL               http://localhost:8080  external http address displayed in commands
+SNIPS_SSH_INTERNAL            URL               ssh://localhost:2222   internal address to listen for ssh requests
+SNIPS_SSH_EXTERNAL            URL               ssh://localhost:2222   external ssh address displayed in commands
+SNIPS_SSH_HOSTKEYPATH         String            data/keys/snips        path to host keys (without extension)
+SNIPS_METRICS_STATSD          URL                                      statsd server address (e.g. udp://localhost:8125)
+SNIPS_METRICS_USEDOGSTATSD    True or False     False                  use dogstatsd instead of statsd
 ```
 
 ### Addresses/Ports

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"text/tabwriter"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 )
@@ -25,8 +26,9 @@ type Config struct {
 	HMACKey string `default:"hmac-and-cheese" desc:"symmetric key used to sign URLs"`
 
 	Limits struct {
-		FileSize     uint64 `default:"1048576" desc:"maximum file size in bytes"`
-		FilesPerUser uint64 `default:"100" desc:"maximum number of files per user"`
+		FileSize        uint64        `default:"1048576" desc:"maximum file size in bytes"`
+		FilesPerUser    uint64        `default:"100" desc:"maximum number of files per user"`
+		SessionDuration time.Duration `default:"15m" desc:"maximum ssh session duration"`
 	}
 
 	DB struct {

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -29,9 +29,11 @@ func MetaHandler(cfg *config.Config) http.HandlerFunc {
 
 		metadata := map[string]interface{}{
 			"limits": map[string]interface{}{
-				"file_size_bytes": cfg.Limits.FileSize,
-				"file_size_human": humanize.Bytes(cfg.Limits.FileSize),
-				"files_per_user":  cfg.Limits.FilesPerUser,
+				"file_size_bytes":         cfg.Limits.FileSize,
+				"file_size_human":         humanize.Bytes(cfg.Limits.FileSize),
+				"files_per_user":          cfg.Limits.FilesPerUser,
+				"ssh_session_dur_seconds": cfg.Limits.SessionDuration.Seconds(),
+				"ssh_session_dur_human":   cfg.Limits.SessionDuration.String(),
 			},
 			"guesser_enabled": cfg.EnableGuesser,
 			"http":            cfg.HTTP.External.String(),

--- a/internal/ssh/constants.go
+++ b/internal/ssh/constants.go
@@ -1,12 +1,7 @@
 package ssh
 
-import (
-	"time"
-)
-
 const (
-	MaxSessionDuration = 15 * time.Minute
-	UploadBufferSize   = 1 * 1024 // 1KB
+	UploadBufferSize = 1 * 1024 // 1KB
 
 	LoggerContextKey      = "logger"
 	RequestIDContextKey   = "request_id"

--- a/internal/ssh/handler.go
+++ b/internal/ssh/handler.go
@@ -86,7 +86,7 @@ func (h *SessionHandler) Interactive(sesh *UserSession) {
 	}
 	defer program.Kill()
 
-	timer := time.NewTimer(MaxSessionDuration)
+	timer := time.NewTimer(h.Config.Limits.SessionDuration)
 	defer timer.Stop()
 
 	go func() {
@@ -97,8 +97,8 @@ func (h *SessionHandler) Interactive(sesh *UserSession) {
 				return
 			case <-timer.C:
 				log.Warn().Msg("max session duration reached")
-				program.Quit()
-				return
+				metrics.IncrCounter([]string{"ssh", "session", "max_duration_reached"}, 1)
+				program.Kill()
 			case w := <-winChan:
 				if program != nil {
 					program.Send(tea.WindowSizeMsg{Width: w.Width, Height: w.Height})
@@ -108,7 +108,9 @@ func (h *SessionHandler) Interactive(sesh *UserSession) {
 	}()
 
 	if _, err := program.Run(); err != nil {
-		log.Error().Err(err).Msg("app exited with error")
+		if !errors.Is(err, tea.ErrProgramKilled) { // don't log if we killed the program (e.g. session duration reached)
+			log.Error().Err(err).Msg("app exited with error")
+		}
 	}
 }
 

--- a/internal/ssh/handler.go
+++ b/internal/ssh/handler.go
@@ -99,6 +99,7 @@ func (h *SessionHandler) Interactive(sesh *UserSession) {
 				log.Warn().Msg("max session duration reached")
 				metrics.IncrCounter([]string{"ssh", "session", "max_duration_reached"}, 1)
 				program.Kill()
+				return
 			case w := <-winChan:
 				if program != nil {
 					program.Send(tea.WindowSizeMsg{Width: w.Width, Height: w.Height})


### PR DESCRIPTION
Fixes:
- #24 

The problem was that we were calling `program.Quit` and immediately returning. The `program.Quit` send an async message to the bubbletea program to start the quit procedure (that includes resetting the user's terminal). Instead, we'll use `program.Kill` which _immediately_ stops the session and resets the client's terminal settings.

Also made the session limit configurable as `SNIPS_LIMITS_SESSIONDURATION` and exposed on the metadata endpoint.