### PR TITLE
Config to extend rendered head element

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -47,6 +47,7 @@ SNIPS_LIMITS_SESSIONDURATION  Duration          15m                    maximum s
 SNIPS_DB_FILEPATH             String            data/snips.db          path to database file
 SNIPS_HTTP_INTERNAL           URL               http://localhost:8080  internal address to listen for http requests
 SNIPS_HTTP_EXTERNAL           URL               http://localhost:8080  external http address displayed in commands
+SNIPS_HTML_EXTENDHEADFILE     String                                   path to html file for extra content in <head>
 SNIPS_SSH_INTERNAL            URL               ssh://localhost:2222   internal address to listen for ssh requests
 SNIPS_SSH_EXTERNAL            URL               ssh://localhost:2222   external ssh address displayed in commands
 SNIPS_SSH_HOSTKEYPATH         String            data/keys/snips        path to host keys (without extension)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,10 @@ type Config struct {
 		External url.URL `default:"http://localhost:8080" desc:"external http address displayed in commands"`
 	}
 
+	HTML struct {
+		ExtendHeadFile string `default:"" desc:"path to html file for extra content in <head>"`
+	}
+
 	SSH struct {
 		Internal    url.URL `default:"ssh://localhost:2222" desc:"internal address to listen for ssh requests"`
 		External    url.URL `default:"ssh://localhost:2222" desc:"external ssh address displayed in commands"`

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 		&webFS,
 		&docsFS,
 		readme,
+		cfg.HTML.ExtendHeadFile,
 	)
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to load assets")

--- a/web/templates/file.go.html
+++ b/web/templates/file.go.html
@@ -10,6 +10,7 @@
   <title>{{ .FileID }} - snips.sh</title>
   <link rel="stylesheet" href="/assets/index.css">
   <script type="module" src="/assets/index.js"></script>
+  {{ ExtendedHeadContent }}
 </head>
 
 <body>


### PR DESCRIPTION
This allows for additional content in the head (e.g. scripts for analytics)