### PR TITLE
Allow private upload  with TTL

### DIFF
--- a/internal/ssh/flags.go
+++ b/internal/ssh/flags.go
@@ -18,6 +18,7 @@ type UploadFlags struct {
 
 	Private   bool
 	Extension string
+	TTL       time.Duration
 }
 
 func (uf *UploadFlags) Parse(out io.Writer, args []string) error {
@@ -26,9 +27,14 @@ func (uf *UploadFlags) Parse(out io.Writer, args []string) error {
 
 	uf.BoolVar(&uf.Private, "private", false, "only accessible via creator or signed urls (optional)")
 	uf.StringVar(&uf.Extension, "ext", "", "set the file extension (optional)")
+	uf.DurationVar(&uf.TTL, "ttl", 0, "lifetime of the signed url(optional)")
 
 	if err := uf.FlagSet.Parse(args); err != nil {
 		return err
+	}
+
+	if uf.TTL.Seconds() > 0 && !uf.Private {
+		return fmt.Errorf("%w: -private", ErrFlagRequied)
 	}
 
 	uf.Extension = strings.TrimPrefix(strings.ToLower(uf.Extension), ".")

--- a/internal/ssh/flags.go
+++ b/internal/ssh/flags.go
@@ -27,7 +27,7 @@ func (uf *UploadFlags) Parse(out io.Writer, args []string) error {
 
 	uf.BoolVar(&uf.Private, "private", false, "only accessible via creator or signed urls (optional)")
 	uf.StringVar(&uf.Extension, "ext", "", "set the file extension (optional)")
-	uf.DurationVar(&uf.TTL, "ttl", 0, "lifetime of the signed url(optional)")
+	uf.DurationVar(&uf.TTL, "ttl", 0, "lifetime of the signed url (optional)")
 
 	if err := uf.FlagSet.Parse(args); err != nil {
 		return err

--- a/internal/ssh/flags_test.go
+++ b/internal/ssh/flags_test.go
@@ -74,7 +74,7 @@ func TestUploadFlags(t *testing.T) {
 			name: "ttl only",
 			args: []string{"-ttl", "30s"},
 			want: ssh.UploadFlags{
-				Private:   true,
+				Private:   false,
 				Extension: "",
 				TTL:       30,
 			},

--- a/internal/ssh/flags_test.go
+++ b/internal/ssh/flags_test.go
@@ -22,7 +22,7 @@ func TestUploadFlags(t *testing.T) {
 			want: ssh.UploadFlags{
 				Private:   false,
 				Extension: "",
-				TTL:       0,
+				TTL:       time.Duration(0),
 			},
 		},
 		{
@@ -31,7 +31,7 @@ func TestUploadFlags(t *testing.T) {
 			want: ssh.UploadFlags{
 				Private:   true,
 				Extension: "",
-				TTL:       0,
+				TTL:       time.Duration(0),
 			},
 		},
 		{
@@ -40,7 +40,7 @@ func TestUploadFlags(t *testing.T) {
 			want: ssh.UploadFlags{
 				Private:   false,
 				Extension: "txt",
-				TTL:       0,
+				TTL:       time.Duration(0),
 			},
 		},
 		{
@@ -49,7 +49,7 @@ func TestUploadFlags(t *testing.T) {
 			want: ssh.UploadFlags{
 				Private:   true,
 				Extension: "txt",
-				TTL:       0,
+				TTL:       time.Duration(0),
 			},
 		},
 		{
@@ -58,7 +58,7 @@ func TestUploadFlags(t *testing.T) {
 			want: ssh.UploadFlags{
 				Private:   false,
 				Extension: "txt",
-				TTL:       0,
+				TTL:       time.Duration(0),
 			},
 		},
 		{
@@ -76,7 +76,7 @@ func TestUploadFlags(t *testing.T) {
 			want: ssh.UploadFlags{
 				Private:   false,
 				Extension: "",
-				TTL:       30,
+				TTL:       time.Duration(30),
 			},
 			err: ssh.ErrFlagRequied,
 		},

--- a/internal/ssh/flags_test.go
+++ b/internal/ssh/flags_test.go
@@ -22,6 +22,7 @@ func TestUploadFlags(t *testing.T) {
 			want: ssh.UploadFlags{
 				Private:   false,
 				Extension: "",
+				TTL:       0,
 			},
 		},
 		{
@@ -30,6 +31,7 @@ func TestUploadFlags(t *testing.T) {
 			want: ssh.UploadFlags{
 				Private:   true,
 				Extension: "",
+				TTL:       0,
 			},
 		},
 		{
@@ -38,6 +40,7 @@ func TestUploadFlags(t *testing.T) {
 			want: ssh.UploadFlags{
 				Private:   false,
 				Extension: "txt",
+				TTL:       0,
 			},
 		},
 		{
@@ -46,6 +49,7 @@ func TestUploadFlags(t *testing.T) {
 			want: ssh.UploadFlags{
 				Private:   true,
 				Extension: "txt",
+				TTL:       0,
 			},
 		},
 		{
@@ -54,7 +58,27 @@ func TestUploadFlags(t *testing.T) {
 			want: ssh.UploadFlags{
 				Private:   false,
 				Extension: "txt",
+				TTL:       0,
 			},
+		},
+		{
+			name: "private and ttl",
+			args: []string{"-private", "-ttl", "30s"},
+			want: ssh.UploadFlags{
+				Private:   true,
+				Extension: "",
+				TTL:       time.Duration(30),
+			},
+		},
+		{
+			name: "ttl only",
+			args: []string{"-ttl", "30s"},
+			want: ssh.UploadFlags{
+				Private:   true,
+				Extension: "",
+				TTL:       30,
+			},
+			err: ssh.ErrFlagRequied,
 		},
 	}
 

--- a/internal/ssh/handler.go
+++ b/internal/ssh/handler.go
@@ -407,9 +407,8 @@ func (h *SessionHandler) Upload(sesh *UserSession) {
 					Title:   "Expiration ⌛",
 					Message: styles.C(styles.Colors.Yellow, expires.Local().Format(time.UnixDate)),
 				}
+				noti.Render(sesh)
 			}
-
-			noti.Render(sesh)
 
 			return
 		}

--- a/internal/ssh/handler.go
+++ b/internal/ssh/handler.go
@@ -383,7 +383,7 @@ func (h *SessionHandler) Upload(sesh *UserSession) {
 				log.Info().Str("file_id", file.ID).Time("expires_at", expires).Msg("private file signed")
 				targetUrl = signedUrl.String()
 			} else {
-				targetUrl = h.Config.HTTPAddressForFile((file.ID))
+				targetUrl = h.Config.HTTPAddressForFile(file.ID)
 			}
 
 			url := lipgloss.NewStyle().

--- a/internal/ssh/handler.go
+++ b/internal/ssh/handler.go
@@ -374,22 +374,22 @@ func (h *SessionHandler) Upload(sesh *UserSession) {
 			}
 			noti.Render(sesh)
 
-			var targetUrl string
+			var targetURL string
 			var expires time.Time
-			var signedUrl url.URL
+			var signedURL url.URL
 
 			if file.Private && flags.TTL.Seconds() > 0 {
-				signedUrl, expires = file.GetSignedURL(h.Config, flags.TTL)
+				signedURL, expires = file.GetSignedURL(h.Config, flags.TTL)
 				log.Info().Str("file_id", file.ID).Time("expires_at", expires).Msg("private file signed")
-				targetUrl = signedUrl.String()
+				targetURL = signedURL.String()
 			} else {
-				targetUrl = h.Config.HTTPAddressForFile(file.ID)
+				targetURL = h.Config.HTTPAddressForFile(file.ID)
 			}
 
 			url := lipgloss.NewStyle().
 				Foreground(styles.Colors.Blue).
 				Underline(true).
-				Render(targetUrl)
+				Render(targetURL)
 
 			noti = Notification{
 				Title:   "URL 🔗",


### PR DESCRIPTION
As specified in #13 , given `-ttl` flag, the upload process will provide user with url link with specified ttl.
Let me know if this is something along that lines of what you were thinking!


<img width="835" alt="Screenshot 2023-05-13 at 02 01 50" src="https://github.com/robherley/snips.sh/assets/45870199/b5391f5a-675f-4f97-8476-5fc04780b1b6">


Will fail without `-private` flag.
<img width="352" alt="Screenshot 2023-05-13 at 01 39 12" src="https://github.com/robherley/snips.sh/assets/45870199/63664bc6-04bd-4364-8ca3-56f71dd4a6e1">

