### PR TITLE
Run lint/test workflows on `pull_request` too

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,9 @@ name: Lint
 
 on:
   push:
+    branches: [ main ]
   pull_request:
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint
 
 on:
   push:
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,9 @@ name: Test
 
 on:
   push:
+    branches: [ main ]
   pull_request:
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   push:
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
since they only run on push, the "Approve Workflow" dialog never appears for PRs from first time contributors

oops :) 