### PR TITLE
Add basic open graph meta tags

### DIFF
--- a/web/templates/file.go.html
+++ b/web/templates/file.go.html
@@ -5,6 +5,12 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta property="og:title" content="{{.FileID}} - snips.sh" />
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="snips.sh" />
+  <meta property="og:description" content="snips.sh is a free, anonymous, open source, snippet hosting service" />
+  <meta property="description" content="snips.sh is a free, anonymous, open source, snippet hosting service" />
+  <meta name="theme-color" content="#0ac5b2" />
   <link rel="icon"
     href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>✂️</text></svg>">
   <title>{{ .FileID }} - snips.sh</title>


### PR DESCRIPTION
adds some open graph meta tags to help websites with displaying embed info.

here's how the link of a file looks now when shared on Discord:
![15_05_2023-02_18_Vencord_Desktop_hB1TELa](https://github.com/robherley/snips.sh/assets/36301891/910fefd4-960b-4b40-8fa7-4069a039278f) 