### PR TITLE
[Minor] Fix: Broken ssh command on upload

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,7 +72,7 @@ func (cfg *Config) HTTPAddressForFile(fileID string) string {
 
 func (cfg *Config) SSHCommandForFile(fileID string) string {
 	sshCommand := fmt.Sprintf("ssh f:%s@%s", fileID, cfg.SSH.External.Hostname())
-	if sshPort := cfg.SSH.External.Port(); sshPort != "22" {
+	if sshPort := cfg.SSH.External.Port(); sshPort != "" && sshPort != "22" {
 		sshCommand += fmt.Sprintf(" -p %s", sshPort)
 	}
 


### PR DESCRIPTION
If `SNIPS_SSH_EXTERNAL` is set without specifying a port, implicitly assuming port 22 (`ssh://my.cool.domain` for example), when a file is uploaded, the `ssh` command generated has an empty `-p` arg.

Before fix:
```
> echo hello there | ssh my.cool.domain
Pseudo-terminal will not be allocated because stdin is not a terminal.

┃ File Uploaded 📤
┃ id: m2yrsM1JeY
┃ size: 12 B • type: plaintext • visibility: public

┃ SSH 📠
┃ ssh f:m2yrsM1JeY@my.cool.domain -p
┃ URL 🔗
┃ https://my.cool.domain/f/m2yrsM1JeY
```

After fix:
```
> echo hello there | ssh my.cool.domain
Pseudo-terminal will not be allocated because stdin is not a terminal.

┃ File Uploaded 📤
┃ id: m2yrsM1JeY
┃ size: 12 B • type: plaintext • visibility: public

┃ SSH 📠
┃ ssh f:m2yrsM1JeY@my.cool.domain
┃ URL 🔗
┃ https://my.cool.domain/f/m2yrsM1JeY
```