### PR TITLE
Make scripts POSIX compliant

### DIFF
--- a/script/atlas
+++ b/script/atlas
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 BINDIR="$(git rev-parse --show-toplevel)"/bin
 BINARY=$BINDIR/atlas

--- a/script/install-libtensorflow
+++ b/script/install-libtensorflow
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # This script downloads and installs libtensorflow (CPU only) for the current platform.
 # If you are on macOS, you can just use `brew install libtensorflow` instead.
@@ -13,7 +13,7 @@ fi
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
-function maybe_sudo() {
+maybe_sudo() {
   if [ "$(id -u)" -ne 0 ]; then
     sudo "$@"
   else

--- a/script/lint
+++ b/script/lint
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 BINDIR="$(git rev-parse --show-toplevel)"/bin
 BINARY=$BINDIR/golangci-lint

--- a/script/record-tape
+++ b/script/record-tape
@@ -1,9 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 TAPEDIR="$(git rev-parse --show-toplevel)"/docs/tapes
 
-if ! command -v vhs &> /dev/null
-then
+if ! command -v vhs >/dev/null 2>&1; then
   echo "vhs not be found, please install it:"
   echo "https://github.com/charmbracelet/vhs#installation"
   exit 1
@@ -14,7 +13,6 @@ if [ $# -gt 0 ]; then
   for tape in "$@"; do
     vhs "$TAPEDIR/$tape".tape -o "$TAPEDIR"/"$tape".gif
   done
-  exit
 else
   echo "specify a tape name to record"
   exit 1

--- a/script/schema-diff
+++ b/script/schema-diff
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 TOPDIR="$(git rev-parse --show-toplevel)"
 SCRIPTDIR="$TOPDIR"/script

--- a/script/ssh-tmp
+++ b/script/ssh-tmp
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Create a temporary SSH key and connect to a remote host with it.
 
 if [ $# -eq 0 ]; then

--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 BINDIR="$(git rev-parse --show-toplevel)"/bin
 BINARY=$BINDIR/gotestsum


### PR DESCRIPTION
There is no reason to prefer `/bin/bash` when none of its unique features are used. Using `/bin/sh` lets you run the script even on those system without `bash` installed (e.g. Alpine Linux, BSD etc)

Also note that using the keyword `function` for function declaration is not standard and you should prefer declare functions by `name()`.