### PR TITLE
Configuration to restrict SSH access

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -8,6 +8,7 @@ The architecture of snips.sh was designed with self-hosting in mind, it's very s
     - [Addresses/Ports](#addressesports)
     - [Database](#database)
     - [Host Keys](#host-keys)
+    - [Limiting Upload Access](#limiting-upload-access)
     - [Statsd Metrics](#statsd-metrics)
   - [Examples](#examples)
     - [Docker Compose](#docker-compose)
@@ -51,6 +52,7 @@ SNIPS_HTML_EXTENDHEADFILE     String                                   path to h
 SNIPS_SSH_INTERNAL            URL               ssh://localhost:2222   internal address to listen for ssh requests
 SNIPS_SSH_EXTERNAL            URL               ssh://localhost:2222   external ssh address displayed in commands
 SNIPS_SSH_HOSTKEYPATH         String            data/keys/snips        path to host keys (without extension)
+SNIPS_SSH_AUTHORIZEDKEYSPATH  String                                   path to authorized keys, if specified will restrict SSH access
 SNIPS_METRICS_STATSD          URL                                      statsd server address (e.g. udp://localhost:8125)
 SNIPS_METRICS_USEDOGSTATSD    True or False     False                  use dogstatsd instead of statsd
 ```
@@ -107,6 +109,32 @@ It is also possible that a host key has just been changed.
 ```
 
 Be sure to securely backup any host keys in the event they might be lost.
+
+### Limiting Upload Access
+
+By default, any user with an SSH public key can upload to a snips.sh instance.
+
+If you want to limit access to who can upload snippets, you can use the `SNIPS_SSH_AUTHORIZEDKEYSPATH` environment variable. If specified, this will limit the SSH server to the public keys defined there.
+
+The format is exactly the same as `authorized_keys` as `sshd(8)`, e.g.
+
+```
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEnqsMuqOhEVw3HyWMp2fqqn6l1IZtJHD1UWkOXszUcl
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBBMu3TbOgxpvYrcQQG6VHSgrwMzAsFg2s+UX5JMNjNI
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKrOJrpYRgEiuGuoNhyPbeEldjIRkwRG/fjjySPUks/y
+```
+
+For an account on GitHub, you can use `https://github.com/<username>.keys` to generate it. For example, if I wanted to allow access for `robherley`:
+
+```
+curl https://github.com/robherley.keys > snips_authorized_keys
+```
+
+Alternatively, tools like [`ssh-import-id`](https://manpages.ubuntu.com/manpages/bionic/man1/ssh-import-id.1.html) can be used as well:
+
+```
+ssh-import-id gh:robherley -o snips_authorized_keys
+```
 
 ### Statsd Metrics
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -8,7 +8,7 @@ The architecture of snips.sh was designed with self-hosting in mind, it's very s
     - [Addresses/Ports](#addressesports)
     - [Database](#database)
     - [Host Keys](#host-keys)
-    - [Limiting Upload Access](#limiting-upload-access)
+    - [Limiting SSH Access](#limiting-ssh-access)
     - [Statsd Metrics](#statsd-metrics)
   - [Examples](#examples)
     - [Docker Compose](#docker-compose)
@@ -110,13 +110,13 @@ It is also possible that a host key has just been changed.
 
 Be sure to securely backup any host keys in the event they might be lost.
 
-### Limiting Upload Access
+### Limiting SSH Access
 
-By default, any user with an SSH public key can upload to a snips.sh instance.
+By default, any user with an public key can connect to a snips.sh instance via SSH.
 
-If you want to limit access to who can upload snippets, you can use the `SNIPS_SSH_AUTHORIZEDKEYSPATH` environment variable. If specified, this will limit the SSH server to the public keys defined there.
+If you want to limit access to who can SSH (and upload) snippets, you can use the `SNIPS_SSH_AUTHORIZEDKEYSPATH` environment variable. If specified, this will limit the SSH server to the public keys defined there.
 
-The format is exactly the same as `authorized_keys` as `sshd(8)`, e.g.
+The format is exactly the same as `authorized_keys` for `sshd(8)`, e.g.
 
 ```
 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEnqsMuqOhEVw3HyWMp2fqqn6l1IZtJHD1UWkOXszUcl

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,82 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/robherley/snips.sh/internal/config"
+	"github.com/robherley/snips.sh/internal/testutil"
+)
+
+func TestConfig_SSHAuthorizedKeys(t *testing.T) {
+	t.Run("no keys", func(t *testing.T) {
+		cfg, err := config.Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		authorizedKeys, err := cfg.SSHAuthorizedKeys()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(authorizedKeys) != 0 {
+			t.Fatalf("expected 0 keys, got %d", len(authorizedKeys))
+		}
+	})
+
+	t.Run("contains invalid key", func(t *testing.T) {
+		authorizedKeysFile := testutil.TempFile(t, "authorized_keys", `
+		ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEnqsMuqOhEVw3HyWMp2fqqn6l1IZtJHD1UWkOXszUcl
+		this is not an authorized key 🦝
+		ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKrOJrpYRgEiuGuoNhyPbeEldjIRkwRG/fjjySPUks/y
+		`)
+
+		t.Setenv("SNIPS_SSH_AUTHORIZEDKEYSPATH", authorizedKeysFile)
+		cfg, err := config.Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		authorizedKeys, err := cfg.SSHAuthorizedKeys()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(authorizedKeys) != 2 {
+			t.Fatalf("expected 2 keys, got %d", len(authorizedKeys))
+		}
+	})
+
+	t.Run("valid keys", func(t *testing.T) {
+		authorizedKeysFile := testutil.TempFile(t, "authorized_keys", `
+		ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEnqsMuqOhEVw3HyWMp2fqqn6l1IZtJHD1UWkOXszUcl
+		ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBBMu3TbOgxpvYrcQQG6VHSgrwMzAsFg2s+UX5JMNjNI
+		ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKrOJrpYRgEiuGuoNhyPbeEldjIRkwRG/fjjySPUks/y
+		`)
+
+		t.Setenv("SNIPS_SSH_AUTHORIZEDKEYSPATH", authorizedKeysFile)
+		cfg, err := config.Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		authorizedKeys, err := cfg.SSHAuthorizedKeys()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(authorizedKeys) != 3 {
+			t.Fatalf("expected 3 keys, got %d", len(authorizedKeys))
+		}
+
+		for i, key := range authorizedKeys {
+			if key.Type() != "ssh-ed25519" {
+				t.Fatalf("key %d has wrong type: %s", i, key.Type())
+			}
+
+			if key.Marshal() == nil {
+				t.Fatalf("key %d is empty", i)
+			}
+		}
+	})
+}

--- a/internal/ssh/middleware.go
+++ b/internal/ssh/middleware.go
@@ -130,9 +130,9 @@ func WithSessionMetrics(next ssh.Handler) ssh.Handler {
 	}
 }
 
-// WithPublicKeyAllowList will block any SSH connections that aren't using a public key in the allow list.
+// WithAuthorizedKeys will block any SSH connections that aren't using a public key in the authorized key list.
 // If authorizedKeys is empty, this middleware will be a no-op.
-func WithPublicKeyAllowList(authorizedKeys []ssh.PublicKey) func(next ssh.Handler) ssh.Handler {
+func WithAuthorizedKeys(authorizedKeys []ssh.PublicKey) func(next ssh.Handler) ssh.Handler {
 	if len(authorizedKeys) == 0 {
 		return func(next ssh.Handler) ssh.Handler {
 			return next
@@ -150,8 +150,8 @@ func WithPublicKeyAllowList(authorizedKeys []ssh.PublicKey) func(next ssh.Handle
 				}
 			}
 
-			metrics.IncrCounter([]string{"ssh", "session", "not_in_allow_list"}, 1)
-			wish.Println(sesh, "❌ Public key not in allow list.")
+			metrics.IncrCounter([]string{"ssh", "session", "not_authorized_key"}, 1)
+			wish.Println(sesh, "❌ Public key not authorized.")
 			_ = sesh.Exit(1)
 		}
 	}

--- a/internal/ssh/middleware.go
+++ b/internal/ssh/middleware.go
@@ -120,11 +120,39 @@ func WithLogger(next ssh.Handler) ssh.Handler {
 	}
 }
 
+// WithSessionMetrics will record metrics for each SSH session.
 func WithSessionMetrics(next ssh.Handler) ssh.Handler {
 	return func(sesh ssh.Session) {
 		start := time.Now()
 		metrics.IncrCounter([]string{"ssh", "session", "connected"}, 1)
 		next(sesh)
 		metrics.MeasureSince([]string{"ssh", "session", "duration"}, start)
+	}
+}
+
+// WithPublicKeyAllowList will block any SSH connections that aren't using a public key in the allow list.
+// If authorizedKeys is empty, this middleware will be a no-op.
+func WithPublicKeyAllowList(authorizedKeys []ssh.PublicKey) func(next ssh.Handler) ssh.Handler {
+	if len(authorizedKeys) == 0 {
+		return func(next ssh.Handler) ssh.Handler {
+			return next
+		}
+	}
+
+	log.Debug().Int("allowed_keys", len(authorizedKeys)).Msgf("using SSH allowlist")
+
+	return func(next ssh.Handler) ssh.Handler {
+		return func(sesh ssh.Session) {
+			for _, key := range authorizedKeys {
+				if ssh.KeysEqual(key, sesh.PublicKey()) {
+					next(sesh)
+					return
+				}
+			}
+
+			metrics.IncrCounter([]string{"ssh", "session", "not_in_allow_list"}, 1)
+			wish.Println(sesh, "❌ Public key not in allow list.")
+			_ = sesh.Exit(1)
+		}
 	}
 }

--- a/internal/ssh/middleware_test.go
+++ b/internal/ssh/middleware_test.go
@@ -179,10 +179,10 @@ func TestWithLogger(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestWithPublicKeyAllowList(t *testing.T) {
-	t.Run("no allowlist", func(t *testing.T) {
+func TestWithAuthorizedKeys(t *testing.T) {
+	t.Run("no authorized keys", func(t *testing.T) {
 		session := testsession.New(t, &cssh.Server{
-			Handler: ssh.WithPublicKeyAllowList(nil)(func(sesh cssh.Session) {}),
+			Handler: ssh.WithAuthorizedKeys(nil)(func(sesh cssh.Session) {}),
 			PublicKeyHandler: func(ctx cssh.Context, key cssh.PublicKey) bool {
 				return true
 			},
@@ -197,13 +197,13 @@ func TestWithPublicKeyAllowList(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("allowlist blocks user", func(t *testing.T) {
+	t.Run("pubkey not in authorized keys", func(t *testing.T) {
 		nextFunc := func(sesh cssh.Session) {
 			panic("this should not be called")
 		}
 
 		session := testsession.New(t, &cssh.Server{
-			Handler: ssh.WithPublicKeyAllowList(
+			Handler: ssh.WithAuthorizedKeys(
 				[]cssh.PublicKey{authorizedKey},
 			)(nextFunc),
 			PublicKeyHandler: func(ctx cssh.Context, key cssh.PublicKey) bool {
@@ -220,9 +220,9 @@ func TestWithPublicKeyAllowList(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("allowlist allows user", func(t *testing.T) {
+	t.Run("pubkey in authorized keys", func(t *testing.T) {
 		session := testsession.New(t, &cssh.Server{
-			Handler: ssh.WithPublicKeyAllowList(
+			Handler: ssh.WithAuthorizedKeys(
 				[]cssh.PublicKey{authorizedKey},
 			)(func(sesh cssh.Session) {}),
 			PublicKeyHandler: func(ctx cssh.Context, key cssh.PublicKey) bool {

--- a/internal/ssh/service.go
+++ b/internal/ssh/service.go
@@ -36,7 +36,7 @@ func New(cfg *config.Config, db db.DB) (*Service, error) {
 		wish.WithMiddleware(
 			sessionHandler.HandleFunc,
 			AssignUser(db, cfg.HTTP.External),
-			WithPublicKeyAllowList(authorizedKeys),
+			WithAuthorizedKeys(authorizedKeys),
 			BlockIfNoPublicKey,
 			WithLogger,
 			WithRequestID,

--- a/internal/ssh/service.go
+++ b/internal/ssh/service.go
@@ -17,6 +17,11 @@ func New(cfg *config.Config, db db.DB) (*Service, error) {
 		DB:     db,
 	}
 
+	authorizedKeys, err := cfg.SSHAuthorizedKeys()
+	if err != nil {
+		return nil, err
+	}
+
 	sshServer, err := wish.NewServer(
 		wish.WithAddress(cfg.SSH.Internal.Host),
 		wish.WithHostKeyPath(cfg.SSH.HostKeyPath),
@@ -31,6 +36,7 @@ func New(cfg *config.Config, db db.DB) (*Service, error) {
 		wish.WithMiddleware(
 			sessionHandler.HandleFunc,
 			AssignUser(db, cfg.HTTP.External),
+			WithPublicKeyAllowList(authorizedKeys),
 			BlockIfNoPublicKey,
 			WithLogger,
 			WithRequestID,

--- a/internal/testutil/file.go
+++ b/internal/testutil/file.go
@@ -1,0 +1,25 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TempFile creates a temporary file with the given filename and content.
+// The file's directory is deleted when the test finishes.
+func TempFile(t *testing.T, filename, content string) string {
+	t.Helper()
+
+	f, err := os.Create(filepath.Join(t.TempDir(), filename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+
+	return f.Name()
+}


### PR DESCRIPTION
A solution for:
- https://github.com/robherley/snips.sh/issues/43

It adds a new configuration variable, `SNIPS_SSH_AUTHORIZEDKEYSPATH` to point to an `authorized_keys`-like file that will restrict SSH access to the public keys defined in that file. If the envvar is not set, it will behave normally. This is opt-in and will not change default behavior.