### PR TITLE
Disable guesser using build tags

### DIFF
--- a/internal/renderer/guess.go
+++ b/internal/renderer/guess.go
@@ -1,4 +1,4 @@
-//go:build arm64
+//go:build arm64 || noguesser
 
 package renderer
 

--- a/internal/renderer/guess_amd64.go
+++ b/internal/renderer/guess_amd64.go
@@ -1,4 +1,4 @@
-//go:build amd64
+//go:build amd64 && !noguesser
 
 package renderer
 


### PR DESCRIPTION
This allow users to build the app without the guesser (and tensorflow) even on amd64 platforms, just using the `-tags noguesser` when building.

It would though gets panic when using with `SNIPS_ENABLEGUESSER=True`. But I guess its fine.