### PR TITLE
Add scroll to highlighted lines

### DIFF
--- a/web/static/js/snips.js
+++ b/web/static/js/snips.js
@@ -2,7 +2,7 @@ import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10.1.0/+esm";
 
 // getSelectedLines will return the lines specified in the hash.
 const getSelectedLines = () => {
-  if (!location.hash?.startsWith("#L")) return [];
+  if (!location.hash.startsWith("#L")) return [];
   return location.hash
     .slice(1)
     .split("-")
@@ -17,14 +17,8 @@ const highlightLines = () => {
     el.classList.remove("hl");
   });
 
-  const hash = location.hash;
-  if (!hash) return;
-
-  const lines = getSelectedLines();
-  if (!lines.length) return;
-
-  const start = lines[0];
-  const end = lines[1] || start;
+  const [start, end = start] = getSelectedLines();
+  if (!start) return;
 
   for (let i = start; i <= end; i++) {
     const el = document.querySelector(`#L${i}`);

--- a/web/static/js/snips.js
+++ b/web/static/js/snips.js
@@ -27,6 +27,17 @@ const highlightLines = () => {
   }
 };
 
+// scrollToLine will scroll to the selected lines on hash #L2
+const scrollToLine = () => {
+  const [start] = getSelectedLines();
+  if (!start) return;
+
+  // needs to defer the execution to be able to scroll even when page gets refresh
+  setTimeout(() => {
+    document.querySelector(`#L${start}`).scrollIntoView({ behavior: "smooth" });
+  }, 100);
+};
+
 // watchForShiftClick watches for shift-clicks on line numbers, and will set the anchor appropriately.
 const watchForShiftClick = () => {
   const chroma = document.querySelector(".chroma");
@@ -100,6 +111,7 @@ window.addEventListener("DOMContentLoaded", () => {
   initHeaderObserver();
   watchForShiftClick();
   highlightLines();
+  scrollToLine();
 
   mermaid.initialize({ startOnLoad: false, theme: "dark" });
   mermaid.run({ querySelector: "code.language-mermaid" });

--- a/web/static/js/snips.js
+++ b/web/static/js/snips.js
@@ -87,6 +87,12 @@ const initHeaderObserver = () => {
   );
 
   observer.observe(nav);
+
+  // do not remove the hightlighted lines when scroll to the top
+  element.addEventListener("click", (event) => {
+    event.preventDefault();
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  });
 };
 
 window.addEventListener("hashchange", highlightLines);

--- a/web/static/js/snips.js
+++ b/web/static/js/snips.js
@@ -80,11 +80,7 @@ const initHeaderObserver = () => {
 
   const observer = new IntersectionObserver(
     ([entry]) => {
-      if (!entry.isIntersecting) {
-        element.removeAttribute("data-hide");
-      } else {
-        element.setAttribute("data-hide", "");
-      }
+      element.toggleAttribute("data-hide", entry.isIntersecting);
     },
     // https://stackoverflow.com/a/61115077
     { rootMargin: "-1px 0px 0px 0px", threshold: [1] }

--- a/web/static/js/snips.js
+++ b/web/static/js/snips.js
@@ -90,13 +90,11 @@ const initHeaderObserver = () => {
 };
 
 window.addEventListener("hashchange", highlightLines);
-window.addEventListener("DOMContentLoaded", async () => {
+window.addEventListener("DOMContentLoaded", () => {
   initHeaderObserver();
   watchForShiftClick();
   highlightLines();
 
   mermaid.initialize({ startOnLoad: false, theme: "dark" });
-  await mermaid.run({
-    querySelector: "code.language-mermaid",
-  });
+  mermaid.run({ querySelector: "code.language-mermaid" });
 });


### PR DESCRIPTION
This is related to issue #175 but I also did some more work, sorry I couldnt resist 😇

- changed a little the `getSelectedLines`:
  `location.hash` will always return string so no need the optional channing
- changed a little the `highlightLines`:
  `getSelectedLines` will always return array and already check the `location.hash` before so I replaced that if and add some deconstruct assignment, just small changes to reduce some lines
- changed the `setAttribute/removeAttribute` for `toggleAttribute` with force parameter, just small change to reduce some lines
- added a new method `scrollToLine` to scroll to the highlighted lines
  it unfortunatelly "needs" the `setTimeout` in order to always get fired, otherwise it will only works for a new page load (not for refresh). It does works better having it.
- added a new block inside `watchForShiftClick` to disable native click on `go to top` to prevent it to remove the currently highlighted lines
- removed `async/await` from DOMContentLoaded as it is not needed