### PR TITLE
Use `net/http` router instead of `chi`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/charmbracelet/ssh v0.0.0-20240725163421-eb71b85b27aa
 	github.com/charmbracelet/wish v1.4.3
 	github.com/dustin/go-humanize v1.0.1
-	github.com/go-chi/chi/v5 v5.1.0
 	github.com/jaevor/go-nanoid v1.4.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/klauspost/compress v1.17.10

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,6 @@ github.com/galeone/tensorflow/tensorflow/go v0.0.0-20221023090153-6b7fa0680c3e h
 github.com/galeone/tensorflow/tensorflow/go v0.0.0-20221023090153-6b7fa0680c3e/go.mod h1:TelZuq26kz2jysARBwOrTv16629hyUsHmIoj54QqyFo=
 github.com/galeone/tfgo v0.0.0-20230214145115-56cedbc50978 h1:8xhEVC2zjvI+3xWkt+78Krkd6JYp+0+iEoBVi0UBlJs=
 github.com/galeone/tfgo v0.0.0-20230214145115-56cedbc50978/go.mod h1:3YgYBeIX42t83uP27Bd4bSMxTnQhSbxl0pYSkCDB1tc=
-github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
-github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=

--- a/internal/http/assets.go
+++ b/internal/http/assets.go
@@ -45,8 +45,7 @@ var (
 type Assets interface {
 	Doc(filename string) ([]byte, error)
 	Template() *template.Template
-	ServeJS(w http.ResponseWriter, r *http.Request)
-	ServeCSS(w http.ResponseWriter, r *http.Request)
+	Serve(w http.ResponseWriter, r *http.Request)
 }
 
 type StaticAssets struct {
@@ -137,12 +136,15 @@ func (a *StaticAssets) Template() *template.Template {
 	return a.tmpl
 }
 
-func (a *StaticAssets) ServeJS(w http.ResponseWriter, r *http.Request) {
-	serve(w, r, a.js, jsMime)
-}
-
-func (a *StaticAssets) ServeCSS(w http.ResponseWriter, r *http.Request) {
-	serve(w, r, a.css, cssMime)
+func (a *StaticAssets) Serve(w http.ResponseWriter, r *http.Request) {
+	switch r.PathValue("asset") {
+	case "index.js":
+		serve(w, r, a.js, jsMime)
+	case "index.css":
+		serve(w, r, a.css, cssMime)
+	default:
+		http.NotFound(w, r)
+	}
 }
 
 // serve serves the content, gzipped if the client accepts it.

--- a/internal/http/service_test.go
+++ b/internal/http/service_test.go
@@ -47,7 +47,7 @@ func (suite *HTTPServiceSuite) SetupTest() {
 }
 
 func (suite *HTTPServiceSuite) TestHTTPServer() {
-	ts := httptest.NewServer(suite.service.Router)
+	ts := httptest.NewServer(suite.service.Handler)
 	defer ts.Close()
 
 	signedFileID := "wdHzc62hsn"


### PR DESCRIPTION
With the routing enhancements introduced in go 1.22:
- https://go.dev/blog/routing-enhancements

We no longer need a separate router dependency, and can rely on the standard library.

Related, the metric `path` is no longer emitted, and instead it's `pattern`.