### PR TITLE
feat(web,ssh): ability to update existing snips & introducing revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ ssh snips.sh
 
 ## Docs
 
+- [Usage](/docs/usage.md): How to upload, download, edit, delete, and share snippets
 - [Contributing](/docs/contributing.md): How you can contribute to snips.sh
 - [Database](/docs/database.md): How snips.sh stores it's data
 - [Self Hosting](/docs/self-hosting.md): How to host your own instance of snips.sh
@@ -96,7 +97,8 @@ The technology behind snips.sh is powered by these amazing projects:
 - [`charmbracelet`](https://github.com/charmbracelet)
   - [`charmbracelet/wish`](https://github.com/charmbracelet/wish): SSH server
   - [`charmbracelet/bubbletea`](https://github.com/charmbracelet/bubbletea): TUI framework
-- [`robherley/magika-go`](https://github.com/robherley/magika-go): AI-powered file type detection
+- [`google/magika`](https://github.com/google/magika): AI-powered file type detection
+  - [`robherley/magika-go`](https://github.com/robherley/magika-go)
 - [`alecthomas/chroma`](https://github.com/alecthomas/chroma): Syntax Highlighter
 - [`yuin/goldmark`](https://github.com/yuin/goldmark): Markdown Parser
 - [`microcosm-cc/bluemonday`](https://github.com/microcosm-cc/bluemonday): HTML Sanitizer

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -39,24 +39,25 @@ docker run ghcr.io/robherley/snips.sh -usage
 ```
 
 ```
-KEY                           TYPE              DEFAULT                DESCRIPTION
-SNIPS_DEBUG                   True or False     False                  enable debug logging and pprof
-SNIPS_ENABLEGUESSER           True or False     True                   enable AI model to detect file types
-SNIPS_HMACKEY                 String            hmac-and-cheese        symmetric key used to sign URLs
-SNIPS_FILECOMPRESSION         True or False     True                   enable compression of file contents
-SNIPS_LIMITS_FILESIZE         Unsigned Integer  1048576                maximum file size in bytes
-SNIPS_LIMITS_FILESPERUSER     Unsigned Integer  100                    maximum number of files per user
-SNIPS_LIMITS_SESSIONDURATION  Duration          15m                    maximum ssh session duration
-SNIPS_DB_FILEPATH             String            data/snips.db          path to database file
-SNIPS_HTTP_INTERNAL           URL               http://localhost:8080  internal address to listen for http requests
-SNIPS_HTTP_EXTERNAL           URL               http://localhost:8080  external http address displayed in commands
-SNIPS_HTML_EXTENDHEADFILE     String                                   path to html file for extra content in <head>
-SNIPS_SSH_INTERNAL            URL               ssh://localhost:2222   internal address to listen for ssh requests
-SNIPS_SSH_EXTERNAL            URL               ssh://localhost:2222   external ssh address displayed in commands
-SNIPS_SSH_HOSTKEYPATH         String            data/keys/snips        path to host keys (without extension)
-SNIPS_SSH_AUTHORIZEDKEYSPATH  String                                   path to authorized keys, if specified will restrict SSH access
-SNIPS_METRICS_STATSD          URL                                      statsd server address (e.g. udp://localhost:8125)
-SNIPS_METRICS_USEDOGSTATSD    True or False     False                  use dogstatsd instead of statsd
+KEY                            TYPE              DEFAULT                DESCRIPTION
+SNIPS_DEBUG                    True or False     False                  enable debug logging and pprof
+SNIPS_ENABLEGUESSER            True or False     True                   enable AI model to detect file types
+SNIPS_HMACKEY                  String            hmac-and-cheese        symmetric key used to sign URLs
+SNIPS_FILECOMPRESSION          True or False     True                   enable compression of file contents
+SNIPS_LIMITS_FILESIZE          Unsigned Integer  1048576                maximum file size in bytes
+SNIPS_LIMITS_FILESPERUSER      Unsigned Integer  100                    maximum number of files per user
+SNIPS_LIMITS_SESSIONDURATION   Duration          15m                    maximum ssh session duration
+SNIPS_LIMITS_REVISIONSPERFILE  Unsigned Integer  64                     maximum number of revisions per file
+SNIPS_DB_FILEPATH              String            data/snips.db          path to database file
+SNIPS_HTTP_INTERNAL            URL               http://localhost:8080  internal address to listen for http requests
+SNIPS_HTTP_EXTERNAL            URL               http://localhost:8080  external http address displayed in commands
+SNIPS_HTML_EXTENDHEADFILE      String                                   path to html file for extra content in <head>
+SNIPS_SSH_INTERNAL             URL               ssh://localhost:2222   internal address to listen for ssh requests
+SNIPS_SSH_EXTERNAL             URL               ssh://localhost:2222   external ssh address displayed in commands
+SNIPS_SSH_HOSTKEYPATH          String            data/keys/snips        path to host keys (without extension)
+SNIPS_SSH_AUTHORIZEDKEYSPATH   String                                   path to authorized keys, if specified will restrict SSH access
+SNIPS_METRICS_STATSD           URL                                      statsd server address (e.g. udp://localhost:8125)
+SNIPS_METRICS_USEDOGSTATSD     True or False     False                  use dogstatsd instead of statsd
 ```
 
 ### Addresses/Ports

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,170 @@
+# Usage
+
+snips.sh is an SSH-driven snippet manager. All interactions happen through your terminal — upload, download, edit, delete, and share files using standard SSH commands. No account creation needed; your SSH key is your identity.
+
+- [Usage](#usage)
+  - [Quick reference](#quick-reference)
+  - [Authentication](#authentication)
+  - [Uploading](#uploading)
+    - [Private uploads](#private-uploads)
+    - [Limits](#limits)
+  - [Downloading](#downloading)
+  - [Updating content](#updating-content)
+  - [Deleting](#deleting)
+  - [Signed URLs](#signed-urls)
+    - [Duration format](#duration-format)
+  - [Interactive TUI](#interactive-tui)
+  - [Web access](#web-access)
+
+## Quick reference
+
+| Action | Command |
+|--------|---------|
+| Upload | `echo "content" \| ssh snips.sh` |
+| Upload (private) | `echo "content" \| ssh snips.sh -private` |
+| Upload (with type hint) | `echo "content" \| ssh snips.sh -ext py` |
+| Upload (private + signed URL) | `echo "content" \| ssh snips.sh -private -ttl 24h` |
+| Download | `ssh f:<id>@snips.sh` |
+| Update | `echo "new" \| ssh f:<id>:content@snips.sh` |
+| Delete | `ssh f:<id>@snips.sh rm` |
+| Force delete | `ssh f:<id>@snips.sh rm -f` |
+| Sign | `ssh f:<id>@snips.sh sign -ttl 1h` |
+| Interactive TUI | `ssh snips.sh` |
+
+## Authentication
+
+snips.sh uses SSH public key authentication exclusively. The first time you connect with a key, a user account is automatically created and linked to your key fingerprint. All files you create are tied to that key.
+
+If your server has an authorized keys file configured, only listed keys will be allowed to connect.
+
+## Uploading
+
+Pipe any content to the SSH server to create a new snippet:
+
+```
+echo "Hello, world!" | ssh snips.sh
+cat main.go | ssh snips.sh
+curl -s https://example.com | ssh snips.sh
+```
+
+The server auto-detects the file type from the content. To override detection, pass an extension hint:
+
+```
+cat config | ssh snips.sh -ext yaml
+```
+
+### Private uploads
+
+By default, files are public. To upload a private file:
+
+```
+echo "secret" | ssh snips.sh -private
+```
+
+Private files are only accessible by the owner (via their SSH key) or through signed URLs.
+
+You can combine `-private` with `-ttl` to get a signed URL back immediately:
+
+```
+echo "secret" | ssh snips.sh -private -ttl 24h
+```
+
+### Limits
+
+- **Max file size:** 1 MB (default)
+- **Max files per user:** 100 (default)
+- Empty files are rejected.
+
+## Downloading
+
+Retrieve a file by connecting as `f:<id>`:
+
+```
+ssh f:abc123@snips.sh
+```
+
+Output goes to stdout, so you can pipe it:
+
+```
+ssh f:abc123@snips.sh > local_copy.txt
+ssh f:abc123@snips.sh | less
+```
+
+Private files can only be downloaded by their owner.
+
+## Updating content
+
+Pipe new content to `f:<id>:content` to replace a file's contents:
+
+```
+echo "updated content" | ssh f:abc123:content@snips.sh
+```
+
+You can also change the file type during an update:
+
+```
+cat renamed.py | ssh f:abc123:content@snips.sh -ext py
+```
+
+Only the file owner can update content. Each update creates a revision with a unified diff of the changes (for text files). Old revisions are pruned once the limit (default 64, but configurable) is reached.
+
+## Deleting
+
+Delete a file with the `rm` command:
+
+```bash
+ssh f:abc123@snips.sh rm
+```
+
+This prompts for confirmation. To skip the prompt:
+
+```bash
+ssh f:abc123@snips.sh rm -f
+```
+
+Only the file owner can delete their files.
+
+## Signed URLs
+
+Private files can be shared via time-limited signed URLs. Use the `sign` command with a `-ttl` duration:
+
+```bash
+ssh f:abc123@snips.sh sign -ttl 1h
+ssh f:abc123@snips.sh sign -ttl 7d
+```
+
+The returned URL can be opened by anyone until it expires. Signing only works on private files.
+
+### Duration format
+
+Durations support these units, and can be combined:
+
+| Unit | Meaning |
+|------|---------|
+| `s`  | seconds |
+| `m`  | minutes |
+| `h`  | hours   |
+| `d`  | days    |
+| `w`  | weeks   |
+
+Examples: `30s`, `2h30m`, `1w2d`, `7d`
+
+## Interactive TUI
+
+Connect without piping to open an interactive terminal UI:
+
+```bash
+ssh snips.sh
+```
+
+The TUI lets you browse your files, view contents, see revision history, delete files, and generate signed URLs. Sessions have a default timeout of 15 minutes.
+
+## Web access
+
+Public files are also available over HTTP:
+
+```
+https://snips.sh/f/<id>
+```
+
+The web view includes syntax highlighting, metadata, and revision history. Private files require a valid signed URL to access over HTTP.

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/muesli/reflow v0.3.0
 	github.com/muesli/termenv v0.16.0
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/robherley/magika-go v0.1.0
 	github.com/stretchr/testify v1.11.1
@@ -67,7 +68,6 @@ require (
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,9 +37,10 @@ type Config struct {
 	FileCompression bool `default:"True" desc:"enable compression of file contents"`
 
 	Limits struct {
-		FileSize        uint64        `default:"1048576" desc:"maximum file size in bytes"`
-		FilesPerUser    uint64        `default:"100" desc:"maximum number of files per user"`
-		SessionDuration time.Duration `default:"15m" desc:"maximum ssh session duration"`
+		FileSize         uint64        `default:"1048576" desc:"maximum file size in bytes"`
+		FilesPerUser     uint64        `default:"100" desc:"maximum number of files per user"`
+		SessionDuration  time.Duration `default:"15m" desc:"maximum ssh session duration"`
+		RevisionsPerFile uint64        `default:"64" desc:"maximum number of revisions per file"`
 	}
 
 	DB struct {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -28,10 +28,10 @@ type DB interface {
 	FindUser(ctx context.Context, id string) (*snips.User, error)
 	// CreateRevision creates a new file revision. If maxRevisions > 0, prunes oldest revisions exceeding the limit.
 	CreateRevision(ctx context.Context, revision *snips.Revision, maxRevisions uint64) error
-	// FindRevisionsByFileID returns all revisions for a file, ordered by id DESC. Does not include diff content.
+	// FindRevisionsByFileID returns all revisions for a file, ordered by sequence DESC. Does not include diff content.
 	FindRevisionsByFileID(ctx context.Context, fileID string) ([]*snips.Revision, error)
-	// FindRevision returns a revision by file ID and revision number, including diff content.
-	FindRevision(ctx context.Context, fileID string, id int64) (*snips.Revision, error)
+	// FindRevisionByFileIDAndSequence returns a revision by file ID and sequence number, including diff content.
+	FindRevisionByFileIDAndSequence(ctx context.Context, fileID string, sequence int64) (*snips.Revision, error)
 	// CountRevisionsByFileID returns the number of revisions for a file.
 	CountRevisionsByFileID(ctx context.Context, fileID string) (int64, error)
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -26,4 +26,14 @@ type DB interface {
 	CreateUserWithPublicKey(ctx context.Context, publickey *snips.PublicKey) (*snips.User, error)
 	// FindUser returns a user by its ID.
 	FindUser(ctx context.Context, id string) (*snips.User, error)
+	// CreateRevision creates a new file revision. If maxRevisions > 0, prunes oldest revisions exceeding the limit.
+	CreateRevision(ctx context.Context, revision *snips.Revision, maxRevisions uint64) error
+	// FindRevisionsByFileID returns all revisions for a file, ordered by id DESC. Does not include diff content.
+	FindRevisionsByFileID(ctx context.Context, fileID string) ([]*snips.Revision, error)
+	// FindRevision returns a revision by file ID and revision number, including diff content.
+	FindRevision(ctx context.Context, fileID string, id int64) (*snips.Revision, error)
+	// CountRevisionsByFileID returns the number of revisions for a file.
+	CountRevisionsByFileID(ctx context.Context, fileID string) (int64, error)
+	// DeleteRevisionsByFileID deletes all revisions for a file.
+	DeleteRevisionsByFileID(ctx context.Context, fileID string) error
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -34,6 +34,4 @@ type DB interface {
 	FindRevision(ctx context.Context, fileID string, id int64) (*snips.Revision, error)
 	// CountRevisionsByFileID returns the number of revisions for a file.
 	CountRevisionsByFileID(ctx context.Context, fileID string) (int64, error)
-	// DeleteRevisionsByFileID deletes all revisions for a file.
-	DeleteRevisionsByFileID(ctx context.Context, fileID string) error
 }

--- a/internal/db/db_mock.go
+++ b/internal/db/db_mock.go
@@ -559,48 +559,48 @@ func (_c *MockDB_FindPublicKeyByFingerprint_Call) RunAndReturn(run func(ctx cont
 	return _c
 }
 
-// FindRevision provides a mock function for the type MockDB
-func (_mock *MockDB) FindRevision(ctx context.Context, fileID string, id int64) (*snips.Revision, error) {
-	ret := _mock.Called(ctx, fileID, id)
+// FindRevisionByFileIDAndSequence provides a mock function for the type MockDB
+func (_mock *MockDB) FindRevisionByFileIDAndSequence(ctx context.Context, fileID string, sequence int64) (*snips.Revision, error) {
+	ret := _mock.Called(ctx, fileID, sequence)
 
 	if len(ret) == 0 {
-		panic("no return value specified for FindRevision")
+		panic("no return value specified for FindRevisionByFileIDAndSequence")
 	}
 
 	var r0 *snips.Revision
 	var r1 error
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int64) (*snips.Revision, error)); ok {
-		return returnFunc(ctx, fileID, id)
+		return returnFunc(ctx, fileID, sequence)
 	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int64) *snips.Revision); ok {
-		r0 = returnFunc(ctx, fileID, id)
+		r0 = returnFunc(ctx, fileID, sequence)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*snips.Revision)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int64) error); ok {
-		r1 = returnFunc(ctx, fileID, id)
+		r1 = returnFunc(ctx, fileID, sequence)
 	} else {
 		r1 = ret.Error(1)
 	}
 	return r0, r1
 }
 
-// MockDB_FindRevision_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindRevision'
-type MockDB_FindRevision_Call struct {
+// MockDB_FindRevisionByFileIDAndSequence_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindRevisionByFileIDAndSequence'
+type MockDB_FindRevisionByFileIDAndSequence_Call struct {
 	*mock.Call
 }
 
-// FindRevision is a helper method to define mock.On call
+// FindRevisionByFileIDAndSequence is a helper method to define mock.On call
 //   - ctx context.Context
 //   - fileID string
-//   - id int64
-func (_e *MockDB_Expecter) FindRevision(ctx interface{}, fileID interface{}, id interface{}) *MockDB_FindRevision_Call {
-	return &MockDB_FindRevision_Call{Call: _e.mock.On("FindRevision", ctx, fileID, id)}
+//   - sequence int64
+func (_e *MockDB_Expecter) FindRevisionByFileIDAndSequence(ctx interface{}, fileID interface{}, sequence interface{}) *MockDB_FindRevisionByFileIDAndSequence_Call {
+	return &MockDB_FindRevisionByFileIDAndSequence_Call{Call: _e.mock.On("FindRevisionByFileIDAndSequence", ctx, fileID, sequence)}
 }
 
-func (_c *MockDB_FindRevision_Call) Run(run func(ctx context.Context, fileID string, id int64)) *MockDB_FindRevision_Call {
+func (_c *MockDB_FindRevisionByFileIDAndSequence_Call) Run(run func(ctx context.Context, fileID string, sequence int64)) *MockDB_FindRevisionByFileIDAndSequence_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -623,12 +623,12 @@ func (_c *MockDB_FindRevision_Call) Run(run func(ctx context.Context, fileID str
 	return _c
 }
 
-func (_c *MockDB_FindRevision_Call) Return(revision *snips.Revision, err error) *MockDB_FindRevision_Call {
+func (_c *MockDB_FindRevisionByFileIDAndSequence_Call) Return(revision *snips.Revision, err error) *MockDB_FindRevisionByFileIDAndSequence_Call {
 	_c.Call.Return(revision, err)
 	return _c
 }
 
-func (_c *MockDB_FindRevision_Call) RunAndReturn(run func(ctx context.Context, fileID string, id int64) (*snips.Revision, error)) *MockDB_FindRevision_Call {
+func (_c *MockDB_FindRevisionByFileIDAndSequence_Call) RunAndReturn(run func(ctx context.Context, fileID string, sequence int64) (*snips.Revision, error)) *MockDB_FindRevisionByFileIDAndSequence_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/db/db_mock.go
+++ b/internal/db/db_mock.go
@@ -355,63 +355,6 @@ func (_c *MockDB_DeleteFile_Call) RunAndReturn(run func(ctx context.Context, id 
 	return _c
 }
 
-// DeleteRevisionsByFileID provides a mock function for the type MockDB
-func (_mock *MockDB) DeleteRevisionsByFileID(ctx context.Context, fileID string) error {
-	ret := _mock.Called(ctx, fileID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for DeleteRevisionsByFileID")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = returnFunc(ctx, fileID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockDB_DeleteRevisionsByFileID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteRevisionsByFileID'
-type MockDB_DeleteRevisionsByFileID_Call struct {
-	*mock.Call
-}
-
-// DeleteRevisionsByFileID is a helper method to define mock.On call
-//   - ctx context.Context
-//   - fileID string
-func (_e *MockDB_Expecter) DeleteRevisionsByFileID(ctx interface{}, fileID interface{}) *MockDB_DeleteRevisionsByFileID_Call {
-	return &MockDB_DeleteRevisionsByFileID_Call{Call: _e.mock.On("DeleteRevisionsByFileID", ctx, fileID)}
-}
-
-func (_c *MockDB_DeleteRevisionsByFileID_Call) Run(run func(ctx context.Context, fileID string)) *MockDB_DeleteRevisionsByFileID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockDB_DeleteRevisionsByFileID_Call) Return(err error) *MockDB_DeleteRevisionsByFileID_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockDB_DeleteRevisionsByFileID_Call) RunAndReturn(run func(ctx context.Context, fileID string) error) *MockDB_DeleteRevisionsByFileID_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // FindFile provides a mock function for the type MockDB
 func (_mock *MockDB) FindFile(ctx context.Context, id string) (*snips.File, error) {
 	ret := _mock.Called(ctx, id)

--- a/internal/db/db_mock.go
+++ b/internal/db/db_mock.go
@@ -38,6 +38,72 @@ func (_m *MockDB) EXPECT() *MockDB_Expecter {
 	return &MockDB_Expecter{mock: &_m.Mock}
 }
 
+// CountRevisionsByFileID provides a mock function for the type MockDB
+func (_mock *MockDB) CountRevisionsByFileID(ctx context.Context, fileID string) (int64, error) {
+	ret := _mock.Called(ctx, fileID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CountRevisionsByFileID")
+	}
+
+	var r0 int64
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (int64, error)); ok {
+		return returnFunc(ctx, fileID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) int64); ok {
+		r0 = returnFunc(ctx, fileID)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, fileID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDB_CountRevisionsByFileID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CountRevisionsByFileID'
+type MockDB_CountRevisionsByFileID_Call struct {
+	*mock.Call
+}
+
+// CountRevisionsByFileID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - fileID string
+func (_e *MockDB_Expecter) CountRevisionsByFileID(ctx interface{}, fileID interface{}) *MockDB_CountRevisionsByFileID_Call {
+	return &MockDB_CountRevisionsByFileID_Call{Call: _e.mock.On("CountRevisionsByFileID", ctx, fileID)}
+}
+
+func (_c *MockDB_CountRevisionsByFileID_Call) Run(run func(ctx context.Context, fileID string)) *MockDB_CountRevisionsByFileID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDB_CountRevisionsByFileID_Call) Return(n int64, err error) *MockDB_CountRevisionsByFileID_Call {
+	_c.Call.Return(n, err)
+	return _c
+}
+
+func (_c *MockDB_CountRevisionsByFileID_Call) RunAndReturn(run func(ctx context.Context, fileID string) (int64, error)) *MockDB_CountRevisionsByFileID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateFile provides a mock function for the type MockDB
 func (_mock *MockDB) CreateFile(ctx context.Context, file *snips.File, maxFiles uint64) error {
 	ret := _mock.Called(ctx, file, maxFiles)
@@ -97,6 +163,69 @@ func (_c *MockDB_CreateFile_Call) Return(err error) *MockDB_CreateFile_Call {
 }
 
 func (_c *MockDB_CreateFile_Call) RunAndReturn(run func(ctx context.Context, file *snips.File, maxFiles uint64) error) *MockDB_CreateFile_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CreateRevision provides a mock function for the type MockDB
+func (_mock *MockDB) CreateRevision(ctx context.Context, revision *snips.Revision, maxRevisions uint64) error {
+	ret := _mock.Called(ctx, revision, maxRevisions)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateRevision")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *snips.Revision, uint64) error); ok {
+		r0 = returnFunc(ctx, revision, maxRevisions)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockDB_CreateRevision_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateRevision'
+type MockDB_CreateRevision_Call struct {
+	*mock.Call
+}
+
+// CreateRevision is a helper method to define mock.On call
+//   - ctx context.Context
+//   - revision *snips.Revision
+//   - maxRevisions uint64
+func (_e *MockDB_Expecter) CreateRevision(ctx interface{}, revision interface{}, maxRevisions interface{}) *MockDB_CreateRevision_Call {
+	return &MockDB_CreateRevision_Call{Call: _e.mock.On("CreateRevision", ctx, revision, maxRevisions)}
+}
+
+func (_c *MockDB_CreateRevision_Call) Run(run func(ctx context.Context, revision *snips.Revision, maxRevisions uint64)) *MockDB_CreateRevision_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *snips.Revision
+		if args[1] != nil {
+			arg1 = args[1].(*snips.Revision)
+		}
+		var arg2 uint64
+		if args[2] != nil {
+			arg2 = args[2].(uint64)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDB_CreateRevision_Call) Return(err error) *MockDB_CreateRevision_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockDB_CreateRevision_Call) RunAndReturn(run func(ctx context.Context, revision *snips.Revision, maxRevisions uint64) error) *MockDB_CreateRevision_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -222,6 +351,63 @@ func (_c *MockDB_DeleteFile_Call) Return(err error) *MockDB_DeleteFile_Call {
 }
 
 func (_c *MockDB_DeleteFile_Call) RunAndReturn(run func(ctx context.Context, id string) error) *MockDB_DeleteFile_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DeleteRevisionsByFileID provides a mock function for the type MockDB
+func (_mock *MockDB) DeleteRevisionsByFileID(ctx context.Context, fileID string) error {
+	ret := _mock.Called(ctx, fileID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteRevisionsByFileID")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, fileID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockDB_DeleteRevisionsByFileID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteRevisionsByFileID'
+type MockDB_DeleteRevisionsByFileID_Call struct {
+	*mock.Call
+}
+
+// DeleteRevisionsByFileID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - fileID string
+func (_e *MockDB_Expecter) DeleteRevisionsByFileID(ctx interface{}, fileID interface{}) *MockDB_DeleteRevisionsByFileID_Call {
+	return &MockDB_DeleteRevisionsByFileID_Call{Call: _e.mock.On("DeleteRevisionsByFileID", ctx, fileID)}
+}
+
+func (_c *MockDB_DeleteRevisionsByFileID_Call) Run(run func(ctx context.Context, fileID string)) *MockDB_DeleteRevisionsByFileID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDB_DeleteRevisionsByFileID_Call) Return(err error) *MockDB_DeleteRevisionsByFileID_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockDB_DeleteRevisionsByFileID_Call) RunAndReturn(run func(ctx context.Context, fileID string) error) *MockDB_DeleteRevisionsByFileID_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -426,6 +612,148 @@ func (_c *MockDB_FindPublicKeyByFingerprint_Call) Return(publicKey *snips.Public
 }
 
 func (_c *MockDB_FindPublicKeyByFingerprint_Call) RunAndReturn(run func(ctx context.Context, fingerprint string) (*snips.PublicKey, error)) *MockDB_FindPublicKeyByFingerprint_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FindRevision provides a mock function for the type MockDB
+func (_mock *MockDB) FindRevision(ctx context.Context, fileID string, id int64) (*snips.Revision, error) {
+	ret := _mock.Called(ctx, fileID, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindRevision")
+	}
+
+	var r0 *snips.Revision
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int64) (*snips.Revision, error)); ok {
+		return returnFunc(ctx, fileID, id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, int64) *snips.Revision); ok {
+		r0 = returnFunc(ctx, fileID, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*snips.Revision)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, int64) error); ok {
+		r1 = returnFunc(ctx, fileID, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDB_FindRevision_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindRevision'
+type MockDB_FindRevision_Call struct {
+	*mock.Call
+}
+
+// FindRevision is a helper method to define mock.On call
+//   - ctx context.Context
+//   - fileID string
+//   - id int64
+func (_e *MockDB_Expecter) FindRevision(ctx interface{}, fileID interface{}, id interface{}) *MockDB_FindRevision_Call {
+	return &MockDB_FindRevision_Call{Call: _e.mock.On("FindRevision", ctx, fileID, id)}
+}
+
+func (_c *MockDB_FindRevision_Call) Run(run func(ctx context.Context, fileID string, id int64)) *MockDB_FindRevision_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 int64
+		if args[2] != nil {
+			arg2 = args[2].(int64)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDB_FindRevision_Call) Return(revision *snips.Revision, err error) *MockDB_FindRevision_Call {
+	_c.Call.Return(revision, err)
+	return _c
+}
+
+func (_c *MockDB_FindRevision_Call) RunAndReturn(run func(ctx context.Context, fileID string, id int64) (*snips.Revision, error)) *MockDB_FindRevision_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FindRevisionsByFileID provides a mock function for the type MockDB
+func (_mock *MockDB) FindRevisionsByFileID(ctx context.Context, fileID string) ([]*snips.Revision, error) {
+	ret := _mock.Called(ctx, fileID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindRevisionsByFileID")
+	}
+
+	var r0 []*snips.Revision
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]*snips.Revision, error)); ok {
+		return returnFunc(ctx, fileID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []*snips.Revision); ok {
+		r0 = returnFunc(ctx, fileID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*snips.Revision)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, fileID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDB_FindRevisionsByFileID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindRevisionsByFileID'
+type MockDB_FindRevisionsByFileID_Call struct {
+	*mock.Call
+}
+
+// FindRevisionsByFileID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - fileID string
+func (_e *MockDB_Expecter) FindRevisionsByFileID(ctx interface{}, fileID interface{}) *MockDB_FindRevisionsByFileID_Call {
+	return &MockDB_FindRevisionsByFileID_Call{Call: _e.mock.On("FindRevisionsByFileID", ctx, fileID)}
+}
+
+func (_c *MockDB_FindRevisionsByFileID_Call) Run(run func(ctx context.Context, fileID string)) *MockDB_FindRevisionsByFileID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDB_FindRevisionsByFileID_Call) Return(revisions []*snips.Revision, err error) *MockDB_FindRevisionsByFileID_Call {
+	_c.Call.Return(revisions, err)
+	return _c
+}
+
+func (_c *MockDB_FindRevisionsByFileID_Call) RunAndReturn(run func(ctx context.Context, fileID string) ([]*snips.Revision, error)) *MockDB_FindRevisionsByFileID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/db/db_sqlite.go
+++ b/internal/db/db_sqlite.go
@@ -483,19 +483,6 @@ func (s *Sqlite) CountRevisionsByFileID(ctx context.Context, fileID string) (int
 	return count, nil
 }
 
-func (s *Sqlite) DeleteRevisionsByFileID(ctx context.Context, fileID string) error {
-	const query = `
-		DELETE FROM revisions
-		WHERE file_id = ?
-	`
-
-	if _, err := s.ExecContext(ctx, query, fileID); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (s *Sqlite) FindUser(ctx context.Context, id string) (*snips.User, error) {
 	const query = `
 		SELECT

--- a/internal/db/db_sqlite.go
+++ b/internal/db/db_sqlite.go
@@ -156,19 +156,6 @@ func (s *Sqlite) UpdateFile(ctx context.Context, file *snips.File) error {
 	return nil
 }
 
-func (s *Sqlite) DeleteFile(ctx context.Context, id string) error {
-	const query = `
-		DELETE FROM files
-		WHERE id = ?
-	`
-
-	if _, err := s.ExecContext(ctx, query, id); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (s *Sqlite) FindFilesByUser(ctx context.Context, userID string) ([]*snips.File, error) {
 	// note that content is _not_ included
 	const query = `
@@ -309,6 +296,204 @@ func (s *Sqlite) CreateUserWithPublicKey(ctx context.Context, publickey *snips.P
 	}
 
 	return user, nil
+}
+
+func (s *Sqlite) DeleteFile(ctx context.Context, id string) error {
+	tx, err := s.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	const deleteRevisionsQuery = `
+		DELETE FROM revisions
+		WHERE file_id = ?
+	`
+
+	if _, err := tx.ExecContext(ctx, deleteRevisionsQuery, id); err != nil {
+		return err
+	}
+
+	const deleteFileQuery = `
+		DELETE FROM files
+		WHERE id = ?
+	`
+
+	if _, err := tx.ExecContext(ctx, deleteFileQuery, id); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (s *Sqlite) CreateRevision(ctx context.Context, revision *snips.Revision, maxRevisions uint64) error {
+	tx, err := s.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	// Get next incrementing ID for this file
+	const nextIDQuery = `
+		SELECT COALESCE(MAX(id), 0) + 1
+		FROM revisions
+		WHERE file_id = ?
+	`
+
+	var nextID int64
+	row := tx.QueryRowContext(ctx, nextIDQuery, revision.FileID)
+	if err := row.Scan(&nextID); err != nil {
+		return err
+	}
+
+	revision.ID = nextID
+	revision.CreatedAt = time.Now().UTC()
+
+	const insertQuery = `
+		INSERT INTO revisions (
+			id,
+			file_id,
+			created_at,
+			diff,
+			size,
+			type
+		) VALUES (?, ?, ?, ?, ?, ?)
+	`
+
+	if _, err := tx.ExecContext(ctx, insertQuery,
+		revision.ID,
+		revision.FileID,
+		revision.CreatedAt,
+		revision.RawDiff,
+		revision.Size,
+		revision.Type,
+	); err != nil {
+		return err
+	}
+
+	// Prune oldest revisions if over the limit
+	if maxRevisions > 0 {
+		const pruneQuery = `
+			DELETE FROM revisions
+			WHERE file_id = ? AND id NOT IN (
+				SELECT id FROM revisions
+				WHERE file_id = ?
+				ORDER BY id DESC
+				LIMIT ?
+			)
+		`
+
+		if _, err := tx.ExecContext(ctx, pruneQuery, revision.FileID, revision.FileID, maxRevisions); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (s *Sqlite) FindRevisionsByFileID(ctx context.Context, fileID string) ([]*snips.Revision, error) {
+	const query = `
+		SELECT
+			id,
+			file_id,
+			created_at,
+			size,
+			type
+		FROM revisions
+		WHERE file_id = ?
+		ORDER BY id DESC
+	`
+
+	rows, err := s.QueryContext(ctx, query, fileID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	revisions := []*snips.Revision{}
+	for rows.Next() {
+		rev := &snips.Revision{}
+		if err := rows.Scan(
+			&rev.ID,
+			&rev.FileID,
+			&rev.CreatedAt,
+			&rev.Size,
+			&rev.Type,
+		); err != nil {
+			return nil, err
+		}
+
+		revisions = append(revisions, rev)
+	}
+
+	return revisions, nil
+}
+
+func (s *Sqlite) FindRevision(ctx context.Context, fileID string, revID int64) (*snips.Revision, error) {
+	const query = `
+		SELECT
+			id,
+			file_id,
+			created_at,
+			diff,
+			size,
+			type
+		FROM revisions
+		WHERE file_id = ? AND id = ?
+	`
+
+	rev := &snips.Revision{}
+	row := s.QueryRowContext(ctx, query, fileID, revID)
+
+	if err := row.Scan(
+		&rev.ID,
+		&rev.FileID,
+		&rev.CreatedAt,
+		&rev.RawDiff,
+		&rev.Size,
+		&rev.Type,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return rev, nil
+}
+
+func (s *Sqlite) CountRevisionsByFileID(ctx context.Context, fileID string) (int64, error) {
+	const query = `
+		SELECT COUNT(*)
+		FROM revisions
+		WHERE file_id = ?
+	`
+
+	var count int64
+	row := s.QueryRowContext(ctx, query, fileID)
+	if err := row.Scan(&count); err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+func (s *Sqlite) DeleteRevisionsByFileID(ctx context.Context, fileID string) error {
+	const query = `
+		DELETE FROM revisions
+		WHERE file_id = ?
+	`
+
+	if _, err := s.ExecContext(ctx, query, fileID); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *Sqlite) FindUser(ctx context.Context, id string) (*snips.User, error) {

--- a/internal/db/migrations/00002_file_revisions.sql
+++ b/internal/db/migrations/00002_file_revisions.sql
@@ -1,13 +1,18 @@
 -- +goose Up
+-- +goose StatementBegin
 CREATE TABLE IF NOT EXISTS `revisions` (
-    `id` integer NOT NULL,
+    `id` text NOT NULL,
+    `sequence` integer NOT NULL,
     `file_id` text NOT NULL,
     `created_at` datetime NOT NULL,
     `diff` blob NOT NULL,
     `size` integer NOT NULL,
     `type` text NOT NULL,
-    PRIMARY KEY (`file_id`, `id`)
+    PRIMARY KEY (`id`)
 );
+
+CREATE INDEX IF NOT EXISTS `idx_revisions_file_id_sequence` ON `revisions` (`file_id`, `sequence`);
+-- +goose StatementEnd
 
 -- +goose Down
 DROP TABLE IF EXISTS `revisions`;

--- a/internal/db/migrations/00002_file_revisions.sql
+++ b/internal/db/migrations/00002_file_revisions.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS `revisions` (
+    `id` integer NOT NULL,
+    `file_id` text NOT NULL,
+    `created_at` datetime NOT NULL,
+    `diff` blob NOT NULL,
+    `size` integer NOT NULL,
+    `type` text NOT NULL,
+    PRIMARY KEY (`file_id`, `id`)
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS `revisions`;

--- a/internal/snips/compress.go
+++ b/internal/snips/compress.go
@@ -1,0 +1,9 @@
+package snips
+
+import "encoding/binary"
+
+// IsZSTDCompressed checks if the data starts with the zstd magic number.
+// https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#zstandard-frames
+func IsZSTDCompressed(data []byte) bool {
+	return len(data) > 4 && binary.BigEndian.Uint32(data) == 0x28B52FFD
+}

--- a/internal/snips/file.go
+++ b/internal/snips/file.go
@@ -1,7 +1,6 @@
 package snips
 
 import (
-	"encoding/binary"
 	"fmt"
 	"net/url"
 	"time"
@@ -56,7 +55,7 @@ func (f *File) Visibility() string {
 }
 
 func (f *File) GetContent() ([]byte, error) {
-	if !f.isCompressed() {
+	if !IsZSTDCompressed(f.RawContent) {
 		return f.RawContent, nil
 	}
 
@@ -84,10 +83,4 @@ func (f *File) SetContent(in []byte, compress bool) error {
 
 	f.RawContent = encoder.EncodeAll(in, nil)
 	return encoder.Close()
-}
-
-func (f *File) isCompressed() bool {
-	// check if first 4 bytes are ZSTD magic number
-	// https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#zstandard-frames
-	return len(f.RawContent) > 4 && binary.BigEndian.Uint32(f.RawContent) == 0x28B52FFD
 }

--- a/internal/snips/revision.go
+++ b/internal/snips/revision.go
@@ -7,7 +7,8 @@ import (
 )
 
 type Revision struct {
-	ID        int64
+	ID        string
+	Sequence  int64
 	FileID    string
 	CreatedAt time.Time
 	RawDiff   []byte // may be zstd-compressed

--- a/internal/snips/revision.go
+++ b/internal/snips/revision.go
@@ -1,0 +1,52 @@
+package snips
+
+import (
+	"encoding/binary"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+type Revision struct {
+	ID        int64
+	FileID    string
+	CreatedAt time.Time
+	RawDiff   []byte // may be zstd-compressed
+	Size      uint64 // file size after this revision
+	Type      string // file type after this revision
+}
+
+func (r *Revision) GetDiff() ([]byte, error) {
+	if !r.isCompressed() {
+		return r.RawDiff, nil
+	}
+
+	decoder, err := zstd.NewReader(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	defer decoder.Close()
+	decodedBytes, err := decoder.DecodeAll(r.RawDiff, nil)
+
+	return decodedBytes, err
+}
+
+func (r *Revision) SetDiff(in []byte, compress bool) error {
+	if !compress {
+		r.RawDiff = in
+		return nil
+	}
+
+	encoder, err := zstd.NewWriter(nil)
+	if err != nil {
+		return err
+	}
+
+	r.RawDiff = encoder.EncodeAll(in, nil)
+	return encoder.Close()
+}
+
+func (r *Revision) isCompressed() bool {
+	return len(r.RawDiff) > 4 && binary.BigEndian.Uint32(r.RawDiff) == 0x28B52FFD
+}

--- a/internal/snips/revision.go
+++ b/internal/snips/revision.go
@@ -1,7 +1,6 @@
 package snips
 
 import (
-	"encoding/binary"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
@@ -17,7 +16,7 @@ type Revision struct {
 }
 
 func (r *Revision) GetDiff() ([]byte, error) {
-	if !r.isCompressed() {
+	if !IsZSTDCompressed(r.RawDiff) {
 		return r.RawDiff, nil
 	}
 
@@ -45,8 +44,4 @@ func (r *Revision) SetDiff(in []byte, compress bool) error {
 
 	r.RawDiff = encoder.EncodeAll(in, nil)
 	return encoder.Close()
-}
-
-func (r *Revision) isCompressed() bool {
-	return len(r.RawDiff) > 4 && binary.BigEndian.Uint32(r.RawDiff) == 0x28B52FFD
 }

--- a/internal/ssh/errors.go
+++ b/internal/ssh/errors.go
@@ -9,6 +9,5 @@ var (
 	ErrPrivateFileAccess = errors.New("private file access")
 	ErrUnknownCommand    = errors.New("unknown command")
 	ErrSignPublicFile    = errors.New("unable to sign public file")
-	ErrOpOnNonOwnedFile  = errors.New("operation on non-owned file")
 	ErrEmptyContent      = errors.New("empty content")
 )

--- a/internal/ssh/errors.go
+++ b/internal/ssh/errors.go
@@ -10,4 +10,5 @@ var (
 	ErrUnknownCommand    = errors.New("unknown command")
 	ErrSignPublicFile    = errors.New("unable to sign public file")
 	ErrOpOnNonOwnedFile  = errors.New("operation on non-owned file")
+	ErrEmptyContent      = errors.New("empty content")
 )

--- a/internal/ssh/flags.go
+++ b/internal/ssh/flags.go
@@ -83,6 +83,27 @@ func (df *DeleteFlags) Parse(out io.Writer, args []string) error {
 	return df.FlagSet.Parse(args)
 }
 
+type UpdateFileContentFlags struct {
+	*flag.FlagSet
+
+	Extension string
+}
+
+func (uf *UpdateFileContentFlags) Parse(out io.Writer, args []string) error {
+	uf.FlagSet = flag.NewFlagSet("", flag.ContinueOnError)
+	uf.SetOutput(out)
+
+	uf.StringVar(&uf.Extension, "ext", "", "hint the file extension (optional)")
+
+	if err := uf.FlagSet.Parse(args); err != nil {
+		return err
+	}
+
+	uf.Extension = strings.TrimPrefix(strings.ToLower(uf.Extension), ".")
+
+	return nil
+}
+
 // durationFlagValue is a wrapper around time.Duration that implements the flag.Value interface using a custom parser.
 type durationFlagValue time.Duration
 

--- a/internal/ssh/session.go
+++ b/internal/ssh/session.go
@@ -29,8 +29,14 @@ func (sesh *UserSession) IsFileRequest() bool {
 	return strings.HasPrefix(sesh.User(), FileRequestPrefix)
 }
 
+func (sesh *UserSession) IsContentUpdate() bool {
+	return strings.HasSuffix(sesh.User(), ":content")
+}
+
 func (sesh *UserSession) RequestedFileID() string {
-	return strings.TrimPrefix(sesh.User(), FileRequestPrefix)
+	id := strings.TrimPrefix(sesh.User(), FileRequestPrefix)
+	id = strings.TrimSuffix(id, ":content")
+	return id
 }
 
 func (sesh *UserSession) Error(err error, title string, f string, v ...interface{}) {

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/dustin/go-humanize"
@@ -54,7 +55,8 @@ func MetaHandler(cfg *config.Config) http.HandlerFunc {
 					"bytes": cfg.Limits.FileSize,
 					"human": humanize.Bytes(cfg.Limits.FileSize),
 				},
-				"files_per_user": cfg.Limits.FilesPerUser,
+				"files_per_user":     cfg.Limits.FilesPerUser,
+				"revisions_per_file": cfg.Limits.RevisionsPerFile,
 				"session_duration": map[string]interface{}{
 					"seconds": cfg.Limits.SessionDuration.Seconds(),
 					"human":   cfg.Limits.SessionDuration.String(),
@@ -253,6 +255,11 @@ func FileHandler(cfg *config.Config, database db.DB, assets Assets) http.Handler
 			css = renderer.GetSyntaxCSS()
 		}
 
+		revisionCount, err := database.CountRevisionsByFileID(r.Context(), file.ID)
+		if err != nil {
+			log.Warn("unable to count revisions", "err", err)
+		}
+
 		ogImageURL := fmt.Sprintf("%s://%s/f/%s/og.png", cfg.HTTP.External.Scheme, cfg.HTTP.External.Host, file.ID)
 		ogDescription := fmt.Sprintf("%s · %s · %s · %s", file.ID, strings.ToLower(file.Type), humanize.Bytes(file.Size), humanize.Time(file.UpdatedAt))
 
@@ -270,6 +277,7 @@ func FileHandler(cfg *config.Config, database db.DB, assets Assets) http.Handler
 			"CommitSHA":     config.BuildCommit(),
 			"OGImageURL":    ogImageURL,
 			"OGDescription": ogDescription,
+			"RevisionCount": revisionCount,
 		}
 
 		err = tmpl.ExecuteTemplate(w, "file.go.html", vars)
@@ -361,6 +369,189 @@ func OGImageHandler(cfg *config.Config, database db.DB, assets Assets) http.Hand
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(imgBytes)
 	}
+}
+
+func RevisionsHandler(cfg *config.Config, database db.DB, assets Assets) http.HandlerFunc {
+	sgnr := signer.New(cfg.HMACKey)
+	tmpl := assets.Template()
+	return func(w http.ResponseWriter, r *http.Request) {
+		log := logger.From(r.Context())
+
+		fileID := r.PathValue("fileID")
+		if fileID == "" {
+			http.NotFound(w, r)
+			return
+		}
+
+		file, err := database.FindFile(r.Context(), fileID)
+		if err != nil {
+			log.Error("unable to lookup file", "err", err)
+			http.NotFound(w, r)
+			return
+		}
+
+		if file == nil {
+			http.NotFound(w, r)
+			return
+		}
+
+		isSignedAndNotExpired := sgnr.VerifyURLAndNotExpired(*r.URL)
+
+		if file.Private && !isSignedAndNotExpired {
+			log.Warn("attempted to access private file revisions")
+			http.NotFound(w, r)
+			return
+		}
+
+		revisions, err := database.FindRevisionsByFileID(r.Context(), file.ID)
+		if err != nil {
+			log.Error("unable to lookup revisions", "err", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		type revisionItem struct {
+			ID        int64
+			CreatedAt string
+			Size      string
+			Type      string
+		}
+
+		items := make([]revisionItem, len(revisions))
+		for i, rev := range revisions {
+			items[i] = revisionItem{
+				ID:        rev.ID,
+				CreatedAt: humanize.Time(rev.CreatedAt),
+				Size:      humanize.Bytes(rev.Size),
+				Type:      strings.ToLower(rev.Type),
+			}
+		}
+
+		vars := map[string]interface{}{
+			"FileID":       file.ID,
+			"FileSize":     humanize.Bytes(file.Size),
+			"FileType":     strings.ToLower(file.Type),
+			"UpdatedAt":    humanize.Time(file.UpdatedAt),
+			"Private":      file.Private,
+			"Revisions":    items,
+			"MaxRevisions": cfg.Limits.RevisionsPerFile,
+			"CommitSHA":    config.BuildCommit(),
+		}
+
+		err = tmpl.ExecuteTemplate(w, "revisions.go.html", vars)
+		if err != nil {
+			log.Error("unable to render template", "err", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+func RevisionDiffHandler(cfg *config.Config, database db.DB, assets Assets) http.HandlerFunc {
+	sgnr := signer.New(cfg.HMACKey)
+	tmpl := assets.Template()
+	return func(w http.ResponseWriter, r *http.Request) {
+		log := logger.From(r.Context())
+
+		fileID := r.PathValue("fileID")
+		revisionIDStr := r.PathValue("revisionID")
+		if fileID == "" || revisionIDStr == "" {
+			http.NotFound(w, r)
+			return
+		}
+
+		revisionID, err := strconv.ParseInt(revisionIDStr, 10, 64)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+
+		file, err := database.FindFile(r.Context(), fileID)
+		if err != nil {
+			log.Error("unable to lookup file", "err", err)
+			http.NotFound(w, r)
+			return
+		}
+
+		if file == nil {
+			http.NotFound(w, r)
+			return
+		}
+
+		isSignedAndNotExpired := sgnr.VerifyURLAndNotExpired(*r.URL)
+
+		if file.Private && !isSignedAndNotExpired {
+			log.Warn("attempted to access private file revision")
+			http.NotFound(w, r)
+			return
+		}
+
+		revision, err := database.FindRevision(r.Context(), file.ID, revisionID)
+		if err != nil {
+			log.Error("unable to lookup revision", "err", err)
+			http.NotFound(w, r)
+			return
+		}
+
+		if revision == nil {
+			http.NotFound(w, r)
+			return
+		}
+
+		diffContent, err := revision.GetDiff()
+		if err != nil {
+			log.Error("unable to decompress diff", "err", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		diffLines := parseDiffLines(string(diffContent))
+
+		vars := map[string]interface{}{
+			"FileID":     file.ID,
+			"FileSize":   humanize.Bytes(file.Size),
+			"FileType":   strings.ToLower(file.Type),
+			"Private":    file.Private,
+			"RevisionID": revision.ID,
+			"CreatedAt":  humanize.Time(revision.CreatedAt),
+			"RevSize":    humanize.Bytes(revision.Size),
+			"RevType":    strings.ToLower(revision.Type),
+			"DiffLines":  diffLines,
+			"CommitSHA":  config.BuildCommit(),
+		}
+
+		err = tmpl.ExecuteTemplate(w, "revision.go.html", vars)
+		if err != nil {
+			log.Error("unable to render template", "err", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+type diffLine struct {
+	Class   string
+	Content string
+}
+
+func parseDiffLines(diff string) []diffLine {
+	lines := strings.Split(diff, "\n")
+	result := make([]diffLine, 0, len(lines))
+	for _, line := range lines {
+		var class string
+		switch {
+		case strings.HasPrefix(line, "+++"), strings.HasPrefix(line, "---"), strings.HasPrefix(line, "@@"):
+			class = "diff-hdr"
+		case strings.HasPrefix(line, "+"):
+			class = "diff-add"
+		case strings.HasPrefix(line, "-"):
+			class = "diff-del"
+		default:
+			class = "diff-ctx"
+		}
+		result = append(result, diffLine{Class: class, Content: line})
+	}
+	return result
 }
 
 func ShouldSendRaw(r *http.Request) bool {

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -123,7 +123,7 @@ func DocHandler(cfg *config.Config, assets Assets) http.HandlerFunc {
 			"OGDescription": ogDescription,
 		}
 
-		err = assets.Template().ExecuteTemplate(w, "file.go.html", vars)
+		err = assets.Template("file.go.html").Execute(w, vars)
 		if err != nil {
 			log.Error("unable to render template", "err", err)
 			http.Error(w, "internal error", http.StatusInternalServerError)
@@ -170,7 +170,6 @@ func DocOGImageHandler(cfg *config.Config, assets Assets) http.HandlerFunc {
 
 func FileHandler(cfg *config.Config, database db.DB, assets Assets) http.HandlerFunc {
 	signer := signer.New(cfg.HMACKey)
-	tmpl := assets.Template()
 	return func(w http.ResponseWriter, r *http.Request) {
 		log := logger.From(r.Context())
 
@@ -280,7 +279,7 @@ func FileHandler(cfg *config.Config, database db.DB, assets Assets) http.Handler
 			"RevisionCount": revisionCount,
 		}
 
-		err = tmpl.ExecuteTemplate(w, "file.go.html", vars)
+		err = assets.Template("file.go.html").Execute(w, vars)
 		if err != nil {
 			log.Error("unable to render template", "err", err)
 			http.Error(w, "internal error", http.StatusInternalServerError)
@@ -373,7 +372,6 @@ func OGImageHandler(cfg *config.Config, database db.DB, assets Assets) http.Hand
 
 func RevisionsHandler(cfg *config.Config, database db.DB, assets Assets) http.HandlerFunc {
 	sgnr := signer.New(cfg.HMACKey)
-	tmpl := assets.Template()
 	return func(w http.ResponseWriter, r *http.Request) {
 		log := logger.From(r.Context())
 
@@ -438,7 +436,7 @@ func RevisionsHandler(cfg *config.Config, database db.DB, assets Assets) http.Ha
 			"CommitSHA":    config.BuildCommit(),
 		}
 
-		err = tmpl.ExecuteTemplate(w, "revisions.go.html", vars)
+		err = assets.Template("revisions.go.html").Execute(w, vars)
 		if err != nil {
 			log.Error("unable to render template", "err", err)
 			http.Error(w, "internal error", http.StatusInternalServerError)
@@ -449,7 +447,6 @@ func RevisionsHandler(cfg *config.Config, database db.DB, assets Assets) http.Ha
 
 func RevisionDiffHandler(cfg *config.Config, database db.DB, assets Assets) http.HandlerFunc {
 	sgnr := signer.New(cfg.HMACKey)
-	tmpl := assets.Template()
 	return func(w http.ResponseWriter, r *http.Request) {
 		log := logger.From(r.Context())
 
@@ -520,7 +517,7 @@ func RevisionDiffHandler(cfg *config.Config, database db.DB, assets Assets) http
 			"CommitSHA":  config.BuildCommit(),
 		}
 
-		err = tmpl.ExecuteTemplate(w, "revision.go.html", vars)
+		err = assets.Template("revision.go.html").Execute(w, vars)
 		if err != nil {
 			log.Error("unable to render template", "err", err)
 			http.Error(w, "internal error", http.StatusInternalServerError)

--- a/internal/web/service.go
+++ b/internal/web/service.go
@@ -20,6 +20,8 @@ func New(cfg *config.Config, database db.DB, assets Assets) (*Service, error) {
 	mux.HandleFunc("GET /docs/{name}/og.png", DocOGImageHandler(cfg, assets))
 	mux.HandleFunc("GET /health", HealthHandler)
 	mux.HandleFunc("GET /f/{fileID}", FileHandler(cfg, database, assets))
+	mux.HandleFunc("GET /f/{fileID}/rev", RevisionsHandler(cfg, database, assets))
+	mux.HandleFunc("GET /f/{fileID}/rev/{revisionID}", RevisionDiffHandler(cfg, database, assets))
 	mux.HandleFunc("GET /f/{fileID}/og.png", OGImageHandler(cfg, database, assets))
 	mux.HandleFunc("GET /assets/{asset...}", assets.Serve)
 	mux.HandleFunc("GET /meta.json", MetaHandler(cfg))

--- a/internal/web/service_test.go
+++ b/internal/web/service_test.go
@@ -338,6 +338,7 @@ func (suite *HTTPServiceSuite) TestFileMarkdownAccept() {
 		file.ID = "mdtest5"
 		file.Type = "go"
 		suite.mockDB.EXPECT().FindFile(mock.Anything, file.ID).Return(&file, nil)
+		suite.mockDB.EXPECT().CountRevisionsByFileID(mock.Anything, file.ID).Return(int64(0), nil)
 
 		req, err := http.NewRequest("GET", ts.URL+"/f/"+file.ID, nil)
 		suite.Require().NoError(err)

--- a/internal/web/service_test.go
+++ b/internal/web/service_test.go
@@ -129,6 +129,7 @@ func (suite *HTTPServiceSuite) TestHTTPServer() {
 				file.ID = "eLcyRMrrgP"
 
 				suite.mockDB.EXPECT().FindFile(mock.Anything, file.ID).Return(&file, nil)
+				suite.mockDB.EXPECT().CountRevisionsByFileID(mock.Anything, file.ID).Return(int64(0), nil)
 			},
 		},
 		{
@@ -155,6 +156,7 @@ func (suite *HTTPServiceSuite) TestHTTPServer() {
 				file.Private = true
 
 				suite.mockDB.EXPECT().FindFile(mock.Anything, file.ID).Return(&file, nil)
+				suite.mockDB.EXPECT().CountRevisionsByFileID(mock.Anything, file.ID).Return(int64(0), nil)
 			},
 		},
 		{

--- a/script/test
+++ b/script/test
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-BINDIR="$(git rev-parse --show-toplevel)"/bin
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BINDIR="${REPO_ROOT}/bin"
 BINARY=$BINDIR/gotestsum
 GOTESTSUM_VERSION=v1.10.0
 
@@ -8,4 +9,5 @@ if [ ! -f "$BINARY" ]; then
   GOBIN=$BINDIR go install gotest.tools/gotestsum@${GOTESTSUM_VERSION}
 fi
 
-$BINARY "$@"
+source "${REPO_ROOT}/script/env"
+$BINARY --raw-command -- go test -json -ldflags "-extldflags \"${GO_EXTLDFLAGS}\"" ./...

--- a/web/static/css/index.css
+++ b/web/static/css/index.css
@@ -309,6 +309,109 @@ svg.lucide {
   line-height: 1.25rem;
 }
 
+.revision-indicator {
+  color: var(--color-primary);
+}
+
+.revision-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.revision-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  color: var(--color-gray);
+  border-bottom: var(--border);
+  text-decoration: none;
+  transition: background-color 0.15s ease;
+}
+
+.revision-item:last-child {
+  border-bottom: none;
+}
+
+.revision-item:hover {
+  background-color: var(--color-surface-2);
+  text-decoration: none;
+}
+
+.revision-item-details {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+}
+
+.revision-item-id {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-primary);
+}
+
+.revision-item-meta {
+  display: flex;
+  gap: 1rem;
+}
+
+.revision-item-time {
+  white-space: nowrap;
+}
+
+.revision-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 2rem;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+}
+
+.revision-note {
+  padding: 0.75rem 1rem;
+  font-family: var(--font-mono);
+  text-align: center;
+  border-top: var(--border);
+}
+
+.diff-content {
+  margin: 0;
+  padding: 1rem;
+  overflow-x: auto;
+  font-size: 0.875rem;
+  line-height: 1.25;
+}
+
+.diff-line {
+  display: block;
+  padding: 0 0.5rem;
+  white-space: pre;
+}
+
+.diff-add {
+  background: color-mix(in srgb, var(--color-green) 15%, transparent);
+  color: var(--color-green);
+}
+
+.diff-del {
+  background: color-mix(in srgb, var(--color-red) 15%, transparent);
+  color: var(--color-red);
+}
+
+.diff-hdr {
+  color: var(--color-primary);
+}
+
+.diff-ctx {
+  color: var(--color-gray);
+}
+
 @media (max-width: 768px) {
   .container {
     padding: 0 0.5rem;

--- a/web/static/js/snips.js
+++ b/web/static/js/snips.js
@@ -1,8 +1,11 @@
 import {
+  ArrowLeft,
+  Clock,
   createIcons,
   FileCode,
   FileText,
   Folder,
+  GitCommitHorizontal,
   HardDrive,
   HatGlasses,
   SquarePen,
@@ -132,13 +135,16 @@ const initHeaderObserver = () => {
 const initIcons = () => {
   createIcons({
     icons: {
-      Terminal,
+      ArrowLeft,
+      Clock,
       FileCode,
-      HardDrive,
-      SquarePen,
-      HatGlasses,
-      Folder,
       FileText,
+      Folder,
+      GitCommitHorizontal,
+      HardDrive,
+      HatGlasses,
+      SquarePen,
+      Terminal,
     },
   });
 };

--- a/web/templates/base.go.html
+++ b/web/templates/base.go.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            property="description"
+            content="snips.sh is a free, anonymous, open source, snippet hosting service"
+        />
+        <meta name="theme-color" content="#0ac5b2" />
+        <link rel="icon" href="/assets/img/favicon.png" />
+        <title>{{ block "title" . }}snips.sh{{ end }}</title>
+        <link rel="stylesheet" href="{{ AssetPath "index.css" }}" />
+        <script type="importmap">
+            {
+                "imports": {
+                    "mermaid": "https://esm.sh/mermaid@11.12.2",
+                    "lucide": "https://esm.sh/lucide@0.562.0"
+                }
+            }
+        </script>
+        {{ block "head" . }}{{ end }}
+        <script type="module" src="{{ AssetPath "index.js" }}"></script>
+        {{ ExtendedHeadContent }}
+    </head>
+
+    <body>
+        <div class="stripes"></div>
+        <div class="container">
+            <h1 class="header">
+                <span class="logo"
+                    ><img src="/assets/img/logo.png" alt="snips logo"
+                /></span>
+                <a class="title" href="/">snips</a>
+            </h1>
+            <nav class="file-header">
+                {{ block "nav" . }}{{ end }}
+            </nav>
+            {{ block "content" . }}{{ end }}
+
+            <div class="footer-stripes-container">
+                <div class="footer-stripes"></div>
+                <div class="color-picker">
+                    <button
+                        class="color-swatch"
+                        data-color="blue"
+                        style="background: var(--color-blue)"
+                        aria-label="Blue"
+                        title="Blue"
+                    ></button>
+                    <button
+                        class="color-swatch"
+                        data-color="red"
+                        style="background: var(--color-red)"
+                        aria-label="Red"
+                        title="Red"
+                    ></button>
+                    <button
+                        class="color-swatch"
+                        data-color="amber"
+                        style="background: var(--color-amber)"
+                        aria-label="Amber"
+                        title="Amber"
+                    ></button>
+                    <button
+                        class="color-swatch"
+                        data-color="green"
+                        style="background: var(--color-green)"
+                        aria-label="Green"
+                        title="Green"
+                    ></button>
+                    <button
+                        class="color-swatch"
+                        data-color="teal"
+                        style="background: var(--color-teal)"
+                        aria-label="Teal"
+                        title="Teal"
+                    ></button>
+                    <button
+                        class="color-swatch"
+                        data-color="purple"
+                        style="background: var(--color-purple)"
+                        aria-label="Purple"
+                        title="Purple"
+                    ></button>
+                    <button
+                        class="color-swatch"
+                        data-color="pink"
+                        style="background: var(--color-pink)"
+                        aria-label="Pink"
+                        title="Pink"
+                    ></button>
+                </div>
+            </div>
+            <footer class="file-footer text-sm muted">
+                <div>
+                    <a href="/">about</a> /
+                    <a href="/docs/terms-of-service.md">terms</a> /
+                    <a href="/docs/acceptable-use-policy.md">acceptable use</a>
+                </div>
+                <div>
+                    snips.sh {{ if .CommitSHA }}/
+                    <a
+                        href="https://github.com/robherley/snips.sh/commit/{{ .CommitSHA }}"
+                        >{{ slice .CommitSHA 0 7 }}</a
+                    >
+                    {{ end }}
+                </div>
+            </footer>
+        </div>
+    </body>
+</html>

--- a/web/templates/base.go.html
+++ b/web/templates/base.go.html
@@ -96,6 +96,7 @@
             <footer class="file-footer text-sm muted">
                 <div>
                     <a href="/">about</a> /
+                    <a href="/docs/usage.md">usage</a> /
                     <a href="/docs/terms-of-service.md">terms</a> /
                     <a href="/docs/acceptable-use-policy.md">acceptable use</a>
                 </div>

--- a/web/templates/file.go.html
+++ b/web/templates/file.go.html
@@ -1,199 +1,90 @@
-<!doctype html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta property="og:title" content="{{.FileID}} - snips.sh" />
-        <meta property="og:type" content="article" />
-        <meta property="og:site_name" content="snips.sh" />
-        <meta property="og:description" content="{{.OGDescription}}" />
-        {{ if .OGImageURL }}
-        <meta property="og:image" content="{{.OGImageURL}}" />
-        {{ end }}
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="{{.FileID}} - snips.sh" />
-        <meta name="twitter:description" content="{{.OGDescription}}" />
-        {{ if .OGImageURL }}
-        <meta name="twitter:image" content="{{.OGImageURL}}" />
-        {{ end }}
-        <meta
-            property="description"
-            content="snips.sh is a free, anonymous, open source, snippet hosting service"
-        />
-        <meta name="theme-color" content="#0ac5b2" />
-        <link rel="icon" href="/assets/img/favicon.png" />
-        <title>{{ .FileID }} - snips.sh</title>
-        <link rel="stylesheet" href="{{ AssetPath "index.css" }}" />
-        <script type="importmap">
-            {
-                "imports": {
-                    "mermaid": "https://esm.sh/mermaid@11.12.2",
-                    "lucide": "https://esm.sh/lucide@0.562.0"
-                }
-            }
-        </script>
-        {{ if .CSS }}
-        <style>
-            {{ .CSS }}
-        </style>
-        {{ end }}
-        <script type="module" src="{{ AssetPath "index.js" }}"></script>
-        {{ ExtendedHeadContent }}
-    </head>
-
-    <body>
-        <div class="stripes"></div>
-        <div class="container">
-            <h1 class="header">
-                <span class="logo"
-                    ><img src="/assets/img/logo.png" alt="snips logo"
-                /></span>
-                <a class="title" href="/">snips</a>
-            </h1>
-            <nav class="file-header">
-                <div class="file-details text-sm">
-                    <div class="file-detail">
-                        <i data-lucide="terminal"></i>
-                        <a href="">{{ .FileID }}</a>
-                    </div>
-                    <div class="file-detail">
-                        <i data-lucide="file-code"></i>
-                        {{ .FileType }}
-                    </div>
-                    <div class="file-detail">
-                        <i data-lucide="hard-drive"></i>
-                        {{ .FileSize }}
-                    </div>
-                    {{ if .UpdatedAt }}
-                    <div class="file-detail">
-                        <i data-lucide="square-pen"></i>
-                        {{ .UpdatedAt }}{{ if .RevisionCount }}<span class="revision-indicator">*</span>{{ end }}
-                    </div>
-                    {{ end }} {{ if .Private }}
-                    <div class="file-detail danger">
-                        <i data-lucide="hat-glasses"></i>
-                        private
-                    </div>
-                    {{ end }}
-                </div>
-                <div class="file-actions">
-                    <a
-                        class="file-action"
-                        id="to-top"
-                        data-hide
-                        aria-label="go to top"
-                        data-shortcut="t"
-                    >
-                        <kbd>t</kbd>top
-                    </a>
-                    {{ if ne .FileType "binary" }}
-                    <button
-                        class="file-action"
-                        id="copy-content"
-                        aria-label="copy to clipboard"
-                        data-shortcut="c"
-                    >
-                        <kbd>c</kbd>copy
-                    </button>
-                    {{ end }} {{ if .RawHREF }}
-                    <a
-                        class="file-action"
-                        id="view-raw"
-                        href="{{ .RawHREF }}"
-                        aria-label="view raw file"
-                        data-shortcut="r"
-                    >
-                        <kbd>r</kbd>raw
-                    </a>
-                    {{ end }} {{ if .RevisionCount }}
-                    <a
-                        class="file-action"
-                        href="/f/{{ .FileID }}/rev"
-                        aria-label="view revision history"
-                        data-shortcut="h"
-                    >
-                        <kbd>h</kbd>history
-                    </a>
-                    {{ end }}
-                </div>
-            </nav>
-            <article class="file-content">{{ .HTML }}</article>
-            {{ if ne .FileType "binary" }}
-            <pre id="raw-content" hidden aria-hidden="true">
-{{ .RawContent }}</pre
-            >
-            {{ end }}
-
-            <div class="footer-stripes-container">
-                <div class="footer-stripes"></div>
-                <div class="color-picker">
-                    <button
-                        class="color-swatch"
-                        data-color="blue"
-                        style="background: var(--color-blue)"
-                        aria-label="Blue"
-                        title="Blue"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="red"
-                        style="background: var(--color-red)"
-                        aria-label="Red"
-                        title="Red"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="amber"
-                        style="background: var(--color-amber)"
-                        aria-label="Amber"
-                        title="Amber"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="green"
-                        style="background: var(--color-green)"
-                        aria-label="Green"
-                        title="Green"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="teal"
-                        style="background: var(--color-teal)"
-                        aria-label="Teal"
-                        title="Teal"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="purple"
-                        style="background: var(--color-purple)"
-                        aria-label="Purple"
-                        title="Purple"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="pink"
-                        style="background: var(--color-pink)"
-                        aria-label="Pink"
-                        title="Pink"
-                    ></button>
-                </div>
-            </div>
-            <footer class="file-footer text-sm muted">
-                <div>
-                    <a href="/">about</a> /
-                    <a href="/docs/terms-of-service.md">terms</a> /
-                    <a href="/docs/acceptable-use-policy.md">acceptable use</a>
-                </div>
-                <div>
-                    snips.sh {{ if .CommitSHA }}/
-                    <a
-                        href="https://github.com/robherley/snips.sh/commit/{{ .CommitSHA }}"
-                        >{{ slice .CommitSHA 0 7 }}</a
-                    >
-                    {{ end }}
-                </div>
-            </footer>
-        </div>
-    </body>
-</html>
+{{ define "title" }}{{ .FileID }} - snips.sh{{ end }} {{ define "head" }}
+<meta property="og:title" content="{{.FileID}} - snips.sh" />
+<meta property="og:type" content="article" />
+<meta property="og:site_name" content="snips.sh" />
+<meta property="og:description" content="{{.OGDescription}}" />
+{{ if .OGImageURL }}
+<meta property="og:image" content="{{.OGImageURL}}" />
+{{ end }}
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="{{.FileID}} - snips.sh" />
+<meta name="twitter:description" content="{{.OGDescription}}" />
+{{ if .OGImageURL }}
+<meta name="twitter:image" content="{{.OGImageURL}}" />
+{{ end }} {{ if .CSS }}
+<style>
+    {{ .CSS }}
+</style>
+{{ end }} {{ end }} {{ define "nav" }}
+<div class="file-details text-sm">
+    <div class="file-detail">
+        <i data-lucide="terminal"></i>
+        <a href="">{{ .FileID }}</a>
+    </div>
+    <div class="file-detail">
+        <i data-lucide="file-code"></i>
+        {{ .FileType }}
+    </div>
+    <div class="file-detail">
+        <i data-lucide="hard-drive"></i>
+        {{ .FileSize }}
+    </div>
+    {{ if .UpdatedAt }}
+    <div class="file-detail">
+        <i data-lucide="square-pen"></i>
+        {{ .UpdatedAt }}{{ if .RevisionCount }}<span class="revision-indicator"
+            >*</span
+        >{{ end }}
+    </div>
+    {{ end }} {{ if .Private }}
+    <div class="file-detail danger">
+        <i data-lucide="hat-glasses"></i>
+        private
+    </div>
+    {{ end }}
+</div>
+<div class="file-actions">
+    <a
+        class="file-action"
+        id="to-top"
+        data-hide
+        aria-label="go to top"
+        data-shortcut="t"
+    >
+        <kbd>t</kbd>top
+    </a>
+    {{ if ne .FileType "binary" }}
+    <button
+        class="file-action"
+        id="copy-content"
+        aria-label="copy to clipboard"
+        data-shortcut="c"
+    >
+        <kbd>c</kbd>copy
+    </button>
+    {{ end }} {{ if .RawHREF }}
+    <a
+        class="file-action"
+        id="view-raw"
+        href="{{ .RawHREF }}"
+        aria-label="view raw file"
+        data-shortcut="r"
+    >
+        <kbd>r</kbd>raw
+    </a>
+    {{ end }} {{ if .RevisionCount }}
+    <a
+        class="file-action"
+        href="/f/{{ .FileID }}/rev"
+        aria-label="view revision history"
+        data-shortcut="h"
+    >
+        <kbd>h</kbd>history
+    </a>
+    {{ end }}
+</div>
+{{ end }} {{ define "content" }}
+<article class="file-content">{{ .HTML }}</article>
+{{ if ne .FileType "binary" }}
+<pre id="raw-content" hidden aria-hidden="true">{{ .RawContent }}</pre>
+{{ end }} {{ end }}

--- a/web/templates/revision.go.html
+++ b/web/templates/revision.go.html
@@ -1,4 +1,4 @@
-{{ define "title" }}{{ .FileID }} revision {{ .RevisionID }} - snips.sh{{ end }}
+{{ define "title" }}{{ .FileID }} revision {{ .RevisionSequence }} - snips.sh{{ end }}
 {{ define "nav" }}
 <div class="file-details text-sm">
     <div class="file-detail">
@@ -7,7 +7,7 @@
     </div>
     <div class="file-detail">
         <i data-lucide="git-commit-horizontal"></i>
-        {{ .RevisionID }}
+        {{ .RevisionSequence }}
     </div>
     <div class="file-detail">
         <i data-lucide="file-code"></i>

--- a/web/templates/revision.go.html
+++ b/web/templates/revision.go.html
@@ -1,141 +1,38 @@
-<!doctype html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta
-            property="description"
-            content="snips.sh is a free, anonymous, open source, snippet hosting service"
-        />
-        <meta name="theme-color" content="#0ac5b2" />
-        <link rel="icon" href="/assets/img/favicon.png" />
-        <title>{{ .FileID }} revision {{ .RevisionID }} - snips.sh</title>
-        <link rel="stylesheet" href="{{ AssetPath "index.css" }}" />
-        <script type="importmap">
-            {
-                "imports": {
-                    "lucide": "https://esm.sh/lucide@0.562.0"
-                }
-            }
-        </script>
-        <script type="module" src="{{ AssetPath "index.js" }}"></script>
-        {{ ExtendedHeadContent }}
-    </head>
-
-    <body>
-        <div class="stripes"></div>
-        <div class="container">
-            <h1 class="header">
-                <span class="logo"
-                    ><img src="/assets/img/logo.png" alt="snips logo"
-                /></span>
-                <a class="title" href="/">snips</a>
-            </h1>
-            <nav class="file-header">
-                <div class="file-details text-sm">
-                    <div class="file-detail">
-                        <i data-lucide="terminal"></i>
-                        <a href="/f/{{ .FileID }}">{{ .FileID }}</a>
-                    </div>
-                    <div class="file-detail">
-                        <i data-lucide="git-commit-horizontal"></i>
-                        {{ .RevisionID }}
-                    </div>
-                    <div class="file-detail">
-                        <i data-lucide="file-code"></i>
-                        {{ .RevType }}
-                    </div>
-                    <div class="file-detail">
-                        <i data-lucide="hard-drive"></i>
-                        {{ .RevSize }}
-                    </div>
-                    <div class="file-detail">
-                        <i data-lucide="clock"></i>
-                        {{ .CreatedAt }}
-                    </div>
-                    {{ if .Private }}
-                    <div class="file-detail danger">
-                        <i data-lucide="hat-glasses"></i>
-                        private
-                    </div>
-                    {{ end }}
-                </div>
-            </nav>
-            <article class="file-content">
-                <pre class="diff-content"><code>{{ range .DiffLines }}<span class="diff-line {{ .Class }}">{{ .Content }}</span>
+{{ define "title" }}{{ .FileID }} revision {{ .RevisionID }} - snips.sh{{ end }}
+{{ define "nav" }}
+<div class="file-details text-sm">
+    <div class="file-detail">
+        <i data-lucide="terminal"></i>
+        <a href="/f/{{ .FileID }}">{{ .FileID }}</a>
+    </div>
+    <div class="file-detail">
+        <i data-lucide="git-commit-horizontal"></i>
+        {{ .RevisionID }}
+    </div>
+    <div class="file-detail">
+        <i data-lucide="file-code"></i>
+        {{ .RevType }}
+    </div>
+    <div class="file-detail">
+        <i data-lucide="hard-drive"></i>
+        {{ .RevSize }}
+    </div>
+    <div class="file-detail">
+        <i data-lucide="clock"></i>
+        {{ .CreatedAt }}
+    </div>
+    {{ if .Private }}
+    <div class="file-detail danger">
+        <i data-lucide="hat-glasses"></i>
+        private
+    </div>
+    {{ end }}
+</div>
+{{ end }} {{ define "content" }}
+<article class="file-content">
+    <pre
+        class="diff-content"
+    ><code>{{ range .DiffLines }}<span class="diff-line {{ .Class }}">{{ .Content }}</span>
 {{ end }}</code></pre>
-            </article>
-
-            <div class="footer-stripes-container">
-                <div class="footer-stripes"></div>
-                <div class="color-picker">
-                    <button
-                        class="color-swatch"
-                        data-color="blue"
-                        style="background: var(--color-blue)"
-                        aria-label="Blue"
-                        title="Blue"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="red"
-                        style="background: var(--color-red)"
-                        aria-label="Red"
-                        title="Red"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="amber"
-                        style="background: var(--color-amber)"
-                        aria-label="Amber"
-                        title="Amber"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="green"
-                        style="background: var(--color-green)"
-                        aria-label="Green"
-                        title="Green"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="teal"
-                        style="background: var(--color-teal)"
-                        aria-label="Teal"
-                        title="Teal"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="purple"
-                        style="background: var(--color-purple)"
-                        aria-label="Purple"
-                        title="Purple"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="pink"
-                        style="background: var(--color-pink)"
-                        aria-label="Pink"
-                        title="Pink"
-                    ></button>
-                </div>
-            </div>
-            <footer class="file-footer text-sm muted">
-                <div>
-                    <a href="/">about</a> /
-                    <a href="/docs/terms-of-service.md">terms</a> /
-                    <a href="/docs/acceptable-use-policy.md">acceptable use</a>
-                </div>
-                <div>
-                    snips.sh {{ if .CommitSHA }}/
-                    <a
-                        href="https://github.com/robherley/snips.sh/commit/{{ .CommitSHA }}"
-                        >{{ slice .CommitSHA 0 7 }}</a
-                    >
-                    {{ end }}
-                </div>
-            </footer>
-        </div>
-    </body>
-</html>
+</article>
+{{ end }}

--- a/web/templates/revision.go.html
+++ b/web/templates/revision.go.html
@@ -4,40 +4,21 @@
         <meta charset="UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta property="og:title" content="{{.FileID}} - snips.sh" />
-        <meta property="og:type" content="article" />
-        <meta property="og:site_name" content="snips.sh" />
-        <meta property="og:description" content="{{.OGDescription}}" />
-        {{ if .OGImageURL }}
-        <meta property="og:image" content="{{.OGImageURL}}" />
-        {{ end }}
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="{{.FileID}} - snips.sh" />
-        <meta name="twitter:description" content="{{.OGDescription}}" />
-        {{ if .OGImageURL }}
-        <meta name="twitter:image" content="{{.OGImageURL}}" />
-        {{ end }}
         <meta
             property="description"
             content="snips.sh is a free, anonymous, open source, snippet hosting service"
         />
         <meta name="theme-color" content="#0ac5b2" />
         <link rel="icon" href="/assets/img/favicon.png" />
-        <title>{{ .FileID }} - snips.sh</title>
+        <title>{{ .FileID }} revision {{ .RevisionID }} - snips.sh</title>
         <link rel="stylesheet" href="{{ AssetPath "index.css" }}" />
         <script type="importmap">
             {
                 "imports": {
-                    "mermaid": "https://esm.sh/mermaid@11.12.2",
                     "lucide": "https://esm.sh/lucide@0.562.0"
                 }
             }
         </script>
-        {{ if .CSS }}
-        <style>
-            {{ .CSS }}
-        </style>
-        {{ end }}
         <script type="module" src="{{ AssetPath "index.js" }}"></script>
         {{ ExtendedHeadContent }}
     </head>
@@ -55,75 +36,36 @@
                 <div class="file-details text-sm">
                     <div class="file-detail">
                         <i data-lucide="terminal"></i>
-                        <a href="">{{ .FileID }}</a>
+                        <a href="/f/{{ .FileID }}">{{ .FileID }}</a>
+                    </div>
+                    <div class="file-detail">
+                        <i data-lucide="git-commit-horizontal"></i>
+                        {{ .RevisionID }}
                     </div>
                     <div class="file-detail">
                         <i data-lucide="file-code"></i>
-                        {{ .FileType }}
+                        {{ .RevType }}
                     </div>
                     <div class="file-detail">
                         <i data-lucide="hard-drive"></i>
-                        {{ .FileSize }}
+                        {{ .RevSize }}
                     </div>
-                    {{ if .UpdatedAt }}
                     <div class="file-detail">
-                        <i data-lucide="square-pen"></i>
-                        {{ .UpdatedAt }}{{ if .RevisionCount }}<span class="revision-indicator">*</span>{{ end }}
+                        <i data-lucide="clock"></i>
+                        {{ .CreatedAt }}
                     </div>
-                    {{ end }} {{ if .Private }}
+                    {{ if .Private }}
                     <div class="file-detail danger">
                         <i data-lucide="hat-glasses"></i>
                         private
                     </div>
                     {{ end }}
                 </div>
-                <div class="file-actions">
-                    <a
-                        class="file-action"
-                        id="to-top"
-                        data-hide
-                        aria-label="go to top"
-                        data-shortcut="t"
-                    >
-                        <kbd>t</kbd>top
-                    </a>
-                    {{ if ne .FileType "binary" }}
-                    <button
-                        class="file-action"
-                        id="copy-content"
-                        aria-label="copy to clipboard"
-                        data-shortcut="c"
-                    >
-                        <kbd>c</kbd>copy
-                    </button>
-                    {{ end }} {{ if .RawHREF }}
-                    <a
-                        class="file-action"
-                        id="view-raw"
-                        href="{{ .RawHREF }}"
-                        aria-label="view raw file"
-                        data-shortcut="r"
-                    >
-                        <kbd>r</kbd>raw
-                    </a>
-                    {{ end }} {{ if .RevisionCount }}
-                    <a
-                        class="file-action"
-                        href="/f/{{ .FileID }}/rev"
-                        aria-label="view revision history"
-                        data-shortcut="h"
-                    >
-                        <kbd>h</kbd>history
-                    </a>
-                    {{ end }}
-                </div>
             </nav>
-            <article class="file-content">{{ .HTML }}</article>
-            {{ if ne .FileType "binary" }}
-            <pre id="raw-content" hidden aria-hidden="true">
-{{ .RawContent }}</pre
-            >
-            {{ end }}
+            <article class="file-content">
+                <pre class="diff-content"><code>{{ range .DiffLines }}<span class="diff-line {{ .Class }}">{{ .Content }}</span>
+{{ end }}</code></pre>
+            </article>
 
             <div class="footer-stripes-container">
                 <div class="footer-stripes"></div>

--- a/web/templates/revisions.go.html
+++ b/web/templates/revisions.go.html
@@ -23,11 +23,11 @@
             <span class="revision-item-time muted"> {{ .UpdatedAt }} </span>
         </a>
         {{ range .Revisions }}
-        <a class="revision-item" href="/f/{{ $.FileID }}/rev/{{ .ID }}">
+        <a class="revision-item" href="/f/{{ $.FileID }}/rev/{{ .Sequence }}">
             <div class="revision-item-details">
                 <span class="revision-item-id">
                     <i data-lucide="git-commit-horizontal"></i>
-                    {{ .ID }}
+                    {{ .Sequence }}
                 </span>
                 <span class="revision-item-meta muted">
                     <span>{{ .Type }}</span>

--- a/web/templates/revisions.go.html
+++ b/web/templates/revisions.go.html
@@ -4,40 +4,21 @@
         <meta charset="UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta property="og:title" content="{{.FileID}} - snips.sh" />
-        <meta property="og:type" content="article" />
-        <meta property="og:site_name" content="snips.sh" />
-        <meta property="og:description" content="{{.OGDescription}}" />
-        {{ if .OGImageURL }}
-        <meta property="og:image" content="{{.OGImageURL}}" />
-        {{ end }}
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="{{.FileID}} - snips.sh" />
-        <meta name="twitter:description" content="{{.OGDescription}}" />
-        {{ if .OGImageURL }}
-        <meta name="twitter:image" content="{{.OGImageURL}}" />
-        {{ end }}
         <meta
             property="description"
             content="snips.sh is a free, anonymous, open source, snippet hosting service"
         />
         <meta name="theme-color" content="#0ac5b2" />
         <link rel="icon" href="/assets/img/favicon.png" />
-        <title>{{ .FileID }} - snips.sh</title>
+        <title>{{ .FileID }} revisions - snips.sh</title>
         <link rel="stylesheet" href="{{ AssetPath "index.css" }}" />
         <script type="importmap">
             {
                 "imports": {
-                    "mermaid": "https://esm.sh/mermaid@11.12.2",
                     "lucide": "https://esm.sh/lucide@0.562.0"
                 }
             }
         </script>
-        {{ if .CSS }}
-        <style>
-            {{ .CSS }}
-        </style>
-        {{ end }}
         <script type="module" src="{{ AssetPath "index.js" }}"></script>
         {{ ExtendedHeadContent }}
     </head>
@@ -55,75 +36,55 @@
                 <div class="file-details text-sm">
                     <div class="file-detail">
                         <i data-lucide="terminal"></i>
-                        <a href="">{{ .FileID }}</a>
+                        <a href="/f/{{ .FileID }}">{{ .FileID }}</a>
                     </div>
-                    <div class="file-detail">
-                        <i data-lucide="file-code"></i>
-                        {{ .FileType }}
-                    </div>
-                    <div class="file-detail">
-                        <i data-lucide="hard-drive"></i>
-                        {{ .FileSize }}
-                    </div>
-                    {{ if .UpdatedAt }}
-                    <div class="file-detail">
-                        <i data-lucide="square-pen"></i>
-                        {{ .UpdatedAt }}{{ if .RevisionCount }}<span class="revision-indicator">*</span>{{ end }}
-                    </div>
-                    {{ end }} {{ if .Private }}
-                    <div class="file-detail danger">
-                        <i data-lucide="hat-glasses"></i>
-                        private
-                    </div>
-                    {{ end }}
-                </div>
-                <div class="file-actions">
-                    <a
-                        class="file-action"
-                        id="to-top"
-                        data-hide
-                        aria-label="go to top"
-                        data-shortcut="t"
-                    >
-                        <kbd>t</kbd>top
-                    </a>
-                    {{ if ne .FileType "binary" }}
-                    <button
-                        class="file-action"
-                        id="copy-content"
-                        aria-label="copy to clipboard"
-                        data-shortcut="c"
-                    >
-                        <kbd>c</kbd>copy
-                    </button>
-                    {{ end }} {{ if .RawHREF }}
-                    <a
-                        class="file-action"
-                        id="view-raw"
-                        href="{{ .RawHREF }}"
-                        aria-label="view raw file"
-                        data-shortcut="r"
-                    >
-                        <kbd>r</kbd>raw
-                    </a>
-                    {{ end }} {{ if .RevisionCount }}
-                    <a
-                        class="file-action"
-                        href="/f/{{ .FileID }}/rev"
-                        aria-label="view revision history"
-                        data-shortcut="h"
-                    >
-                        <kbd>h</kbd>history
-                    </a>
-                    {{ end }}
                 </div>
             </nav>
-            <article class="file-content">{{ .HTML }}</article>
-            {{ if ne .FileType "binary" }}
-            <pre id="raw-content" hidden aria-hidden="true">
-{{ .RawContent }}</pre
-            >
-            {{ end }}
+            <div class="file-content">
+                <div class="revision-list">
+                    <a
+                        class="revision-item"
+                        href="/f/{{ .FileID }}"
+                    >
+                        <div class="revision-item-details">
+                            <span class="revision-item-id">
+                                <i data-lucide="file-code"></i>
+                                current
+                            </span>
+                            <span class="revision-item-meta muted">
+                                <span>{{ .FileType }}</span>
+                                <span>{{ .FileSize }}</span>
+                            </span>
+                        </div>
+                        <span class="revision-item-time muted">
+                            {{ .UpdatedAt }}
+                        </span>
+                    </a>
+                    {{ range .Revisions }}
+                    <a
+                        class="revision-item"
+                        href="/f/{{ $.FileID }}/rev/{{ .ID }}"
+                    >
+                        <div class="revision-item-details">
+                            <span class="revision-item-id">
+                                <i data-lucide="git-commit-horizontal"></i>
+                                {{ .ID }}
+                            </span>
+                            <span class="revision-item-meta muted">
+                                <span>{{ .Type }}</span>
+                                <span>{{ .Size }}</span>
+                            </span>
+                        </div>
+                        <span class="revision-item-time muted">
+                            {{ .CreatedAt }}
+                        </span>
+                    </a>
+                    {{ end }}
+                </div>
+                <div class="revision-note muted text-sm">
+                    note: only the past {{ .MaxRevisions }} revisions are retained
+                </div>
+            </div>
 
             <div class="footer-stripes-container">
                 <div class="footer-stripes"></div>

--- a/web/templates/revisions.go.html
+++ b/web/templates/revisions.go.html
@@ -1,160 +1,45 @@
-<!doctype html>
-<html lang="en">
-    <head>
-        <meta charset="UTF-8" />
-        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <meta
-            property="description"
-            content="snips.sh is a free, anonymous, open source, snippet hosting service"
-        />
-        <meta name="theme-color" content="#0ac5b2" />
-        <link rel="icon" href="/assets/img/favicon.png" />
-        <title>{{ .FileID }} revisions - snips.sh</title>
-        <link rel="stylesheet" href="{{ AssetPath "index.css" }}" />
-        <script type="importmap">
-            {
-                "imports": {
-                    "lucide": "https://esm.sh/lucide@0.562.0"
-                }
-            }
-        </script>
-        <script type="module" src="{{ AssetPath "index.js" }}"></script>
-        {{ ExtendedHeadContent }}
-    </head>
-
-    <body>
-        <div class="stripes"></div>
-        <div class="container">
-            <h1 class="header">
-                <span class="logo"
-                    ><img src="/assets/img/logo.png" alt="snips logo"
-                /></span>
-                <a class="title" href="/">snips</a>
-            </h1>
-            <nav class="file-header">
-                <div class="file-details text-sm">
-                    <div class="file-detail">
-                        <i data-lucide="terminal"></i>
-                        <a href="/f/{{ .FileID }}">{{ .FileID }}</a>
-                    </div>
-                </div>
-            </nav>
-            <div class="file-content">
-                <div class="revision-list">
-                    <a
-                        class="revision-item"
-                        href="/f/{{ .FileID }}"
-                    >
-                        <div class="revision-item-details">
-                            <span class="revision-item-id">
-                                <i data-lucide="file-code"></i>
-                                current
-                            </span>
-                            <span class="revision-item-meta muted">
-                                <span>{{ .FileType }}</span>
-                                <span>{{ .FileSize }}</span>
-                            </span>
-                        </div>
-                        <span class="revision-item-time muted">
-                            {{ .UpdatedAt }}
-                        </span>
-                    </a>
-                    {{ range .Revisions }}
-                    <a
-                        class="revision-item"
-                        href="/f/{{ $.FileID }}/rev/{{ .ID }}"
-                    >
-                        <div class="revision-item-details">
-                            <span class="revision-item-id">
-                                <i data-lucide="git-commit-horizontal"></i>
-                                {{ .ID }}
-                            </span>
-                            <span class="revision-item-meta muted">
-                                <span>{{ .Type }}</span>
-                                <span>{{ .Size }}</span>
-                            </span>
-                        </div>
-                        <span class="revision-item-time muted">
-                            {{ .CreatedAt }}
-                        </span>
-                    </a>
-                    {{ end }}
-                </div>
-                <div class="revision-note muted text-sm">
-                    note: only the past {{ .MaxRevisions }} revisions are retained
-                </div>
+{{ define "title" }}{{ .FileID }} revisions - snips.sh{{ end }} {{ define "nav"
+}}
+<div class="file-details text-sm">
+    <div class="file-detail">
+        <i data-lucide="terminal"></i>
+        <a href="/f/{{ .FileID }}">{{ .FileID }}</a>
+    </div>
+</div>
+{{ end }} {{ define "content" }}
+<div class="file-content">
+    <div class="revision-list">
+        <a class="revision-item" href="/f/{{ .FileID }}">
+            <div class="revision-item-details">
+                <span class="revision-item-id">
+                    <i data-lucide="file-code"></i>
+                    current
+                </span>
+                <span class="revision-item-meta muted">
+                    <span>{{ .FileType }}</span>
+                    <span>{{ .FileSize }}</span>
+                </span>
             </div>
-
-            <div class="footer-stripes-container">
-                <div class="footer-stripes"></div>
-                <div class="color-picker">
-                    <button
-                        class="color-swatch"
-                        data-color="blue"
-                        style="background: var(--color-blue)"
-                        aria-label="Blue"
-                        title="Blue"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="red"
-                        style="background: var(--color-red)"
-                        aria-label="Red"
-                        title="Red"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="amber"
-                        style="background: var(--color-amber)"
-                        aria-label="Amber"
-                        title="Amber"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="green"
-                        style="background: var(--color-green)"
-                        aria-label="Green"
-                        title="Green"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="teal"
-                        style="background: var(--color-teal)"
-                        aria-label="Teal"
-                        title="Teal"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="purple"
-                        style="background: var(--color-purple)"
-                        aria-label="Purple"
-                        title="Purple"
-                    ></button>
-                    <button
-                        class="color-swatch"
-                        data-color="pink"
-                        style="background: var(--color-pink)"
-                        aria-label="Pink"
-                        title="Pink"
-                    ></button>
-                </div>
+            <span class="revision-item-time muted"> {{ .UpdatedAt }} </span>
+        </a>
+        {{ range .Revisions }}
+        <a class="revision-item" href="/f/{{ $.FileID }}/rev/{{ .ID }}">
+            <div class="revision-item-details">
+                <span class="revision-item-id">
+                    <i data-lucide="git-commit-horizontal"></i>
+                    {{ .ID }}
+                </span>
+                <span class="revision-item-meta muted">
+                    <span>{{ .Type }}</span>
+                    <span>{{ .Size }}</span>
+                </span>
             </div>
-            <footer class="file-footer text-sm muted">
-                <div>
-                    <a href="/">about</a> /
-                    <a href="/docs/terms-of-service.md">terms</a> /
-                    <a href="/docs/acceptable-use-policy.md">acceptable use</a>
-                </div>
-                <div>
-                    snips.sh {{ if .CommitSHA }}/
-                    <a
-                        href="https://github.com/robherley/snips.sh/commit/{{ .CommitSHA }}"
-                        >{{ slice .CommitSHA 0 7 }}</a
-                    >
-                    {{ end }}
-                </div>
-            </footer>
-        </div>
-    </body>
-</html>
+            <span class="revision-item-time muted"> {{ .CreatedAt }} </span>
+        </a>
+        {{ end }}
+    </div>
+    <div class="revision-note muted text-sm">
+        note: only the past {{ .MaxRevisions }} revisions are retained
+    </div>
+</div>
+{{ end }}


### PR DESCRIPTION
For: #218 

This adds the concept of "revisions" where a snippet can be updated over SSH.

```
cat "new" | ssh f:<id>:content@snips.sh
```

For example, if we create a snip:

<img width="603" height="194" alt="image" src="https://github.com/user-attachments/assets/f133c943-ff68-4560-9812-eafb0be47ef0" />

We can now overwrite the content:

<img width="601" height="192" alt="image" src="https://github.com/user-attachments/assets/4292f71a-a625-4496-a30b-054b12f7c6a7" />


In the web UI, there is now a history action:

<img width="298" height="101" alt="image" src="https://github.com/user-attachments/assets/38a82d2d-4273-4100-9c9a-9ad1e17c9a63" />

Which will bring you two the first new page, the revisions list:

<img width="859" height="297" alt="image" src="https://github.com/user-attachments/assets/a4147dc4-3af1-42d1-a486-a7da4e099a06" />

And then clicking on a revision, you can see the diff:

<img width="854" height="412" alt="image" src="https://github.com/user-attachments/assets/bc202511-8c8e-45a5-9d61-4b1691c08fac" />

To prevent unlimited revisions, it's configurable and defaults to `64`.