### PR TITLE
bugfix(ui): overflow `scroll` to `auto`

### DIFF
--- a/web/static/css/index.css
+++ b/web/static/css/index.css
@@ -181,7 +181,7 @@ svg.lucide {
   border-radius: var(--border-radius);
   z-index: 999;
   background-color: var(--color-surface-1);
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .file-header .file-details {


### PR DESCRIPTION
fix visual bug when scrollbars are set to always visible in macos

<img width="1225" height="207" alt="image" src="https://github.com/user-attachments/assets/9f3f47ca-38e6-4dd2-b4d8-08d0c6e37c05" />
