### PR TITLE
feat(tui): allow named aliases of files

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,7 @@ snips.sh is an SSH-driven snippet manager. All interactions happen through your 
     - [Limits](#limits)
   - [Downloading](#downloading)
   - [Updating content](#updating-content)
+  - [Naming](#naming)
   - [Deleting](#deleting)
   - [Signed URLs](#signed-urls)
     - [Duration format](#duration-format)
@@ -24,8 +25,12 @@ snips.sh is an SSH-driven snippet manager. All interactions happen through your 
 | Upload (private) | `echo "content" \| ssh snips.sh -- -private` |
 | Upload (with type hint) | `echo "content" \| ssh snips.sh -- -ext py` |
 | Upload (private + signed URL) | `echo "content" \| ssh snips.sh -- -private -ttl 24h` |
+| Upload (named) | `echo "content" \| ssh snips.sh -- -name my-notes` |
 | Download | `ssh f:<id>@snips.sh` |
+| Download (by name) | `ssh n:<name>@snips.sh` |
 | Update | `echo "new" \| ssh f:<id>:content@snips.sh` |
+| Rename | `ssh f:<id>@snips.sh -- rename my-notes` |
+| Remove name | `ssh f:<id>@snips.sh -- rename -rm` |
 | Delete | `ssh f:<id>@snips.sh -- rm` |
 | Force delete | `ssh f:<id>@snips.sh -- rm -f` |
 | Sign | `ssh f:<id>@snips.sh -- sign -ttl 1h` |
@@ -107,6 +112,32 @@ cat renamed.py | ssh f:abc123:content@snips.sh -ext py
 ```
 
 Only the file owner can update content. Each update creates a revision with a unified diff of the changes (for text files). Old revisions are pruned once the limit (default 64, but configurable) is reached.
+
+## Naming
+
+Files can be given a human-readable name that appears in the web URL:
+
+```bash
+echo "content" | ssh snips.sh -name deploy-notes   # name at upload
+ssh f:abc123@snips.sh -- rename deploy-notes          # name an existing file
+```
+
+Names may contain letters, numbers, hyphens, dots, and underscores (up to 40 characters).
+
+Named files can also be referenced over SSH with the `n:` prefix anywhere `f:<id>` works — downloads, updates, and commands:
+
+```bash
+ssh n:deploy-notes@snips.sh                        # download by name
+echo "new" | ssh n:deploy-notes:content@snips.sh   # update by name
+```
+
+To remove a name:
+
+```bash
+ssh f:abc123@snips.sh rename -rm
+```
+
+You can also rename files from the interactive TUI via the options menu.
 
 ## Deleting
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,8 +83,23 @@ func (cfg *Config) HTTPAddressForFile(fileID string) string {
 	return httpAddr.String()
 }
 
+func (cfg *Config) HTTPAddressForNamedFile(fileID, name string) string {
+	httpAddr := cfg.HTTP.External
+	httpAddr.Path = fmt.Sprintf("/f/%s/n/%s", fileID, name)
+
+	return httpAddr.String()
+}
+
 func (cfg *Config) SSHCommandForFile(fileID string) string {
-	sshCommand := fmt.Sprintf("ssh f:%s@%s", fileID, cfg.SSH.External.Hostname())
+	return cfg.sshCommandFor("f:" + fileID)
+}
+
+func (cfg *Config) SSHCommandForNamedFile(name string) string {
+	return cfg.sshCommandFor("n:" + name)
+}
+
+func (cfg *Config) sshCommandFor(user string) string {
+	sshCommand := fmt.Sprintf("ssh %s@%s", user, cfg.SSH.External.Hostname())
 	if sshPort := cfg.SSH.External.Port(); sshPort != "" && sshPort != "22" {
 		sshCommand += fmt.Sprintf(" -p %s", sshPort)
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -21,6 +21,8 @@ type DB interface {
 	DeleteFilesByUser(ctx context.Context, userID string) (int64, error)
 	// FindFilesByUser returns all files for a user. Does not include file content.
 	FindFilesByUser(ctx context.Context, userID string) ([]*snips.File, error)
+	// FindFileByName returns a user's file with the given name (case-insensitive). Includes file content.
+	FindFileByName(ctx context.Context, userID, name string) (*snips.File, error)
 	// CountFilesByUser returns the number of files a user has.
 	CountFilesByUser(ctx context.Context, userID string) (int64, error)
 	// FindPublicKeyByFingerprint returns a public key by its fingerprint.

--- a/internal/db/db_mock.go
+++ b/internal/db/db_mock.go
@@ -555,6 +555,80 @@ func (_c *MockDB_FindFile_Call) RunAndReturn(run func(ctx context.Context, id st
 	return _c
 }
 
+// FindFileByName provides a mock function for the type MockDB
+func (_mock *MockDB) FindFileByName(ctx context.Context, userID string, name string) (*snips.File, error) {
+	ret := _mock.Called(ctx, userID, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindFileByName")
+	}
+
+	var r0 *snips.File
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (*snips.File, error)); ok {
+		return returnFunc(ctx, userID, name)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) *snips.File); ok {
+		r0 = returnFunc(ctx, userID, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*snips.File)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, userID, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDB_FindFileByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindFileByName'
+type MockDB_FindFileByName_Call struct {
+	*mock.Call
+}
+
+// FindFileByName is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+//   - name string
+func (_e *MockDB_Expecter) FindFileByName(ctx any, userID any, name any) *MockDB_FindFileByName_Call {
+	return &MockDB_FindFileByName_Call{Call: _e.mock.On("FindFileByName", ctx, userID, name)}
+}
+
+func (_c *MockDB_FindFileByName_Call) Run(run func(ctx context.Context, userID string, name string)) *MockDB_FindFileByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDB_FindFileByName_Call) Return(file *snips.File, err error) *MockDB_FindFileByName_Call {
+	_c.Call.Return(file, err)
+	return _c
+}
+
+func (_c *MockDB_FindFileByName_Call) RunAndReturn(run func(ctx context.Context, userID string, name string) (*snips.File, error)) *MockDB_FindFileByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FindFilesByUser provides a mock function for the type MockDB
 func (_mock *MockDB) FindFilesByUser(ctx context.Context, userID string) ([]*snips.File, error) {
 	ret := _mock.Called(ctx, userID)

--- a/internal/db/db_sqlite.go
+++ b/internal/db/db_sqlite.go
@@ -5,13 +5,13 @@ import (
 	"database/sql"
 	"embed"
 	"errors"
+	"strings"
 	"time"
 
+	"github.com/mattn/go-sqlite3"
 	"github.com/pressly/goose/v3"
 	"github.com/robherley/snips.sh/internal/id"
 	"github.com/robherley/snips.sh/internal/snips"
-
-	_ "github.com/mattn/go-sqlite3" // sqlite driver
 )
 
 //go:embed migrations/*.sql
@@ -50,13 +50,18 @@ func (s *Sqlite) FindFile(ctx context.Context, id string) (*snips.File, error) {
 			content,
 			private,
 			type,
-			user_id
+			user_id,
+			name
 		FROM files
 		WHERE id = ?
 	`
 
+	return scanFile(s.QueryRowContext(ctx, query, id))
+}
+
+func scanFile(row *sql.Row) (*snips.File, error) {
 	file := &snips.File{}
-	row := s.QueryRowContext(ctx, query, id)
+	name := sql.NullString{}
 
 	if err := row.Scan(
 		&file.ID,
@@ -67,6 +72,7 @@ func (s *Sqlite) FindFile(ctx context.Context, id string) (*snips.File, error) {
 		&file.Private,
 		&file.Type,
 		&file.UserID,
+		&name,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
@@ -75,7 +81,26 @@ func (s *Sqlite) FindFile(ctx context.Context, id string) (*snips.File, error) {
 		return nil, err
 	}
 
+	file.Name = name.String
 	return file, nil
+}
+
+// nullableName stores unnamed files as NULL rather than empty string.
+func nullableName(name string) sql.NullString {
+	return sql.NullString{String: name, Valid: name != ""}
+}
+
+// nameConstraintErr maps a violation of the per-user unique name index to
+// ErrNameTaken so callers can show a friendly message.
+func nameConstraintErr(err error) error {
+	sqliteErr := sqlite3.Error{}
+	if errors.As(err, &sqliteErr) &&
+		sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique &&
+		strings.Contains(sqliteErr.Error(), "files.name") {
+		return ErrNameTaken
+	}
+
+	return err
 }
 
 func (s *Sqlite) CreateFile(ctx context.Context, file *snips.File, maxFileCount uint64) error {
@@ -108,8 +133,9 @@ func (s *Sqlite) CreateFile(ctx context.Context, file *snips.File, maxFileCount 
 			content,
 			private,
 			type,
-			user_id
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			user_id,
+			name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
 	if _, err := s.ExecContext(ctx, insertQuery,
@@ -121,8 +147,9 @@ func (s *Sqlite) CreateFile(ctx context.Context, file *snips.File, maxFileCount 
 		file.Private,
 		file.Type,
 		file.UserID,
+		nullableName(file.Name),
 	); err != nil {
-		return err
+		return nameConstraintErr(err)
 	}
 
 	return nil
@@ -138,7 +165,8 @@ func (s *Sqlite) UpdateFile(ctx context.Context, file *snips.File) error {
 			size = ?,
 			content = ?,
 			private = ?,
-			type = ?
+			type = ?,
+			name = ?
 		WHERE id = ?
 	`
 
@@ -148,9 +176,10 @@ func (s *Sqlite) UpdateFile(ctx context.Context, file *snips.File) error {
 		file.RawContent,
 		file.Private,
 		file.Type,
+		nullableName(file.Name),
 		file.ID,
 	); err != nil {
-		return err
+		return nameConstraintErr(err)
 	}
 
 	return nil
@@ -166,7 +195,8 @@ func (s *Sqlite) FindFilesByUser(ctx context.Context, userID string) ([]*snips.F
 			size,
 			private,
 			type,
-			user_id
+			user_id,
+			name
 		FROM files
 		WHERE user_id = ?
 		ORDER BY updated_at DESC
@@ -181,6 +211,7 @@ func (s *Sqlite) FindFilesByUser(ctx context.Context, userID string) ([]*snips.F
 	files := []*snips.File{}
 	for rows.Next() {
 		file := &snips.File{}
+		name := sql.NullString{}
 		if err := rows.Scan(
 			&file.ID,
 			&file.CreatedAt,
@@ -189,14 +220,36 @@ func (s *Sqlite) FindFilesByUser(ctx context.Context, userID string) ([]*snips.F
 			&file.Private,
 			&file.Type,
 			&file.UserID,
+			&name,
 		); err != nil {
 			return nil, err
 		}
 
+		file.Name = name.String
 		files = append(files, file)
 	}
 
 	return files, nil
+}
+
+func (s *Sqlite) FindFileByName(ctx context.Context, userID, name string) (*snips.File, error) {
+	// names are unique per user, so at most one row can match
+	const query = `
+		SELECT
+			id,
+			created_at,
+			updated_at,
+			size,
+			content,
+			private,
+			type,
+			user_id,
+			name
+		FROM files
+		WHERE user_id = ? AND name = ? COLLATE NOCASE
+	`
+
+	return scanFile(s.QueryRowContext(ctx, query, userID, name))
 }
 
 func (s *Sqlite) CountFilesByUser(ctx context.Context, userID string) (int64, error) {

--- a/internal/db/db_sqlite_test.go
+++ b/internal/db/db_sqlite_test.go
@@ -640,3 +640,147 @@ func (s *SqliteSuite) TestFindUser_DoesNotExist() {
 	s.Require().NoError(err)
 	s.Require().Nil(user)
 }
+
+func (s *SqliteSuite) createFile(database *db.Sqlite, name string) *snips.File {
+	file := &snips.File{
+		Size:       11,
+		RawContent: []byte("hello world"),
+		Private:    false,
+		Type:       "plaintext",
+		UserID:     id.New(),
+		Name:       name,
+	}
+
+	err := database.CreateFile(context.Background(), file, 0)
+	s.Require().NoError(err)
+
+	return file
+}
+
+func (s *SqliteSuite) TestCreateFile_WithName() {
+	database := s.getTestDB(true)
+
+	file := s.createFile(database, "deploy-notes")
+
+	found, err := database.FindFile(context.Background(), file.ID)
+	s.Require().NoError(err)
+	s.Require().NotNil(found)
+	s.Require().Equal("deploy-notes", found.Name)
+}
+
+func (s *SqliteSuite) TestUpdateFile_SetAndClearName() {
+	database := s.getTestDB(true)
+
+	file := s.createFile(database, "")
+
+	found, err := database.FindFile(context.Background(), file.ID)
+	s.Require().NoError(err)
+	s.Require().Empty(found.Name)
+
+	file.Name = "deploy-notes"
+	s.Require().NoError(database.UpdateFile(context.Background(), file))
+
+	found, err = database.FindFile(context.Background(), file.ID)
+	s.Require().NoError(err)
+	s.Require().Equal("deploy-notes", found.Name)
+
+	file.Name = ""
+	s.Require().NoError(database.UpdateFile(context.Background(), file))
+
+	found, err = database.FindFile(context.Background(), file.ID)
+	s.Require().NoError(err)
+	s.Require().Empty(found.Name)
+}
+
+func (s *SqliteSuite) TestNames_NotUniqueAcrossUsers() {
+	database := s.getTestDB(true)
+
+	// different users can reuse a name — the file ID is what disambiguates
+	first := s.createFile(database, "deploy-notes")
+	second := s.createFile(database, "deploy-notes")
+
+	s.Require().NotEqual(first.ID, second.ID)
+	s.Require().NotEqual(first.UserID, second.UserID)
+
+	for _, f := range []*snips.File{first, second} {
+		found, err := database.FindFile(context.Background(), f.ID)
+		s.Require().NoError(err)
+		s.Require().Equal("deploy-notes", found.Name)
+	}
+}
+
+func (s *SqliteSuite) TestNames_UniquePerUser() {
+	database := s.getTestDB(true)
+
+	first := s.createFile(database, "deploy-notes")
+
+	duplicate := &snips.File{
+		Size:       11,
+		RawContent: []byte("hello world"),
+		Type:       "plaintext",
+		UserID:     first.UserID,
+		Name:       "Deploy-Notes", // same name, different case
+	}
+	err := database.CreateFile(context.Background(), duplicate, 0)
+	s.Require().ErrorIs(err, db.ErrNameTaken)
+
+	// renaming another file to a taken name fails too
+	other := &snips.File{
+		Size:       11,
+		RawContent: []byte("hello world"),
+		Type:       "plaintext",
+		UserID:     first.UserID,
+	}
+	s.Require().NoError(database.CreateFile(context.Background(), other, 0))
+
+	other.Name = "DEPLOY-NOTES"
+	err = database.UpdateFile(context.Background(), other)
+	s.Require().ErrorIs(err, db.ErrNameTaken)
+
+	// updating a file without changing its own name is fine
+	first.Size = 22
+	s.Require().NoError(database.UpdateFile(context.Background(), first))
+
+	// unnamed files don't participate in the index: many per user are fine
+	for range 2 {
+		unnamed := &snips.File{
+			Size:       11,
+			RawContent: []byte("hello world"),
+			Type:       "plaintext",
+			UserID:     first.UserID,
+		}
+		s.Require().NoError(database.CreateFile(context.Background(), unnamed, 0))
+	}
+}
+
+func (s *SqliteSuite) TestFindFilesByUser_IncludesName() {
+	database := s.getTestDB(true)
+
+	file := s.createFile(database, "deploy-notes")
+
+	files, err := database.FindFilesByUser(context.Background(), file.UserID)
+	s.Require().NoError(err)
+	s.Require().Len(files, 1)
+	s.Require().Equal("deploy-notes", files[0].Name)
+}
+
+func (s *SqliteSuite) TestFindFileByName() {
+	database := s.getTestDB(true)
+
+	first := s.createFile(database, "Deploy-Notes")
+	s.createFile(database, "other")
+
+	// another user's file with the same name is out of scope
+	s.createFile(database, "deploy-notes")
+
+	// case-insensitive, scoped to the user, includes content
+	file, err := database.FindFileByName(context.Background(), first.UserID, "DEPLOY-NOTES")
+	s.Require().NoError(err)
+	s.Require().NotNil(file)
+	s.Require().Equal(first.ID, file.ID)
+	s.Require().Equal(first.RawContent, file.RawContent)
+
+	file, err = database.FindFileByName(context.Background(), first.UserID, "nope")
+	s.Require().NoError(err)
+	s.Require().Nil(file)
+}

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -4,4 +4,5 @@ import "errors"
 
 var (
 	ErrFileLimit = errors.New("file limit reached")
+	ErrNameTaken = errors.New("file already exists with that name")
 )

--- a/internal/db/migrations/00004_file_names.sql
+++ b/internal/db/migrations/00004_file_names.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE `files` ADD COLUMN `name` text;
+
+-- names are unique per user (case-insensitively); unnamed files are NULL and
+-- exempt from the index
+CREATE UNIQUE INDEX IF NOT EXISTS `idx_files_user_id_name` ON `files` (`user_id`, `name` COLLATE NOCASE) WHERE `name` IS NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS `idx_files_user_id_name`;
+
+ALTER TABLE `files` DROP COLUMN `name`;
+-- +goose StatementEnd

--- a/internal/snips/file.go
+++ b/internal/snips/file.go
@@ -24,6 +24,14 @@ type File struct {
 	Private    bool
 	Type       string
 	UserID     string
+	Name       string
+}
+
+func (f *File) DisplayName() string {
+	if f.Name != "" {
+		return fmt.Sprintf("%s (%s)", f.Name, f.ID)
+	}
+	return f.ID
 }
 
 func (f *File) IsBinary() bool {

--- a/internal/snips/name.go
+++ b/internal/snips/name.go
@@ -1,0 +1,35 @@
+package snips
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	// NameMaxLength is the maximum length of a file's name.
+	NameMaxLength = 40
+)
+
+var (
+	ErrInvalidName = fmt.Errorf("names must be 1-%d alphanumeric characters (hyphen, dot, or underscore separators allowed)", NameMaxLength)
+
+	// nameRegex matches alphanumeric words separated by single hyphens, dots,
+	// or underscores. Requiring the name to start and end with an alphanumeric
+	// rune also rules out "." and ".." path segments.
+	nameRegex = regexp.MustCompile(`^[a-zA-Z0-9]+(?:[-._][a-zA-Z0-9]+)*$`)
+)
+
+func NormalizeName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+
+	if name == "" || len(name) > NameMaxLength {
+		return "", ErrInvalidName
+	}
+
+	if !nameRegex.MatchString(name) {
+		return "", ErrInvalidName
+	}
+
+	return name, nil
+}

--- a/internal/snips/name_test.go
+++ b/internal/snips/name_test.go
@@ -1,0 +1,142 @@
+package snips_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/robherley/snips.sh/internal/snips"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeName(t *testing.T) {
+	testcases := []struct {
+		name  string
+		input string
+		want  string
+		err   error
+	}{
+		{
+			name:  "simple",
+			input: "notes",
+			want:  "notes",
+		},
+		{
+			name:  "casing preserved",
+			input: "DeployNotes",
+			want:  "DeployNotes",
+		},
+		{
+			name:  "hyphen separators",
+			input: "deploy-notes-2024",
+			want:  "deploy-notes-2024",
+		},
+		{
+			name:  "dot separators",
+			input: "main.go",
+			want:  "main.go",
+		},
+		{
+			name:  "underscore separators",
+			input: "my_notes",
+			want:  "my_notes",
+		},
+		{
+			name:  "mixed separators and casing",
+			input: "Deploy-Notes.v2_final",
+			want:  "Deploy-Notes.v2_final",
+		},
+		{
+			name:  "leading underscore",
+			input: "_private",
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "leading dot",
+			input: ".hidden",
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "trailing dot",
+			input: "notes.",
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "consecutive dots",
+			input: "a..b",
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "dot path segment",
+			input: "..",
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "surrounding whitespace",
+			input: "  notes  ",
+			want:  "notes",
+		},
+		{
+			name:  "empty",
+			input: "",
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "whitespace only",
+			input: "   ",
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "leading hyphen",
+			input: "-notes",
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "trailing hyphen",
+			input: "notes-",
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "consecutive hyphens",
+			input: "deploy--notes",
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "invalid characters",
+			input: "deploy_notes!",
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "interior whitespace",
+			input: "deploy notes",
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "path traversal",
+			input: "../secrets",
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "too long",
+			input: strings.Repeat("a", snips.NameMaxLength+1),
+			err:   snips.ErrInvalidName,
+		},
+		{
+			name:  "max length",
+			input: strings.Repeat("a", snips.NameMaxLength),
+			want:  strings.Repeat("a", snips.NameMaxLength),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := snips.NormalizeName(tc.input)
+
+			if tc.err != nil {
+				assert.ErrorIs(t, err, tc.err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/ssh/constants.go
+++ b/internal/ssh/constants.go
@@ -8,5 +8,6 @@ const (
 	FingerprintContextKey = "fingerprint"
 	UserIDContextKey      = "user_id"
 
-	FileRequestPrefix = "f:"
+	FileRequestPrefix      = "f:"
+	NamedFileRequestPrefix = "n:"
 )

--- a/internal/ssh/errors.go
+++ b/internal/ssh/errors.go
@@ -10,4 +10,5 @@ var (
 	ErrUnknownCommand    = errors.New("unknown command")
 	ErrSignPublicFile    = errors.New("unable to sign public file")
 	ErrEmptyContent      = errors.New("empty content")
+	ErrNameRequired      = errors.New("name required")
 )

--- a/internal/ssh/flags.go
+++ b/internal/ssh/flags.go
@@ -32,7 +32,7 @@ func (uf *UploadFlags) Parse(out io.Writer, args []string) error {
 	uf.BoolVar(&uf.Private, "private", false, "only accessible via creator or signed urls (optional)")
 	uf.StringVar(&uf.Extension, "ext", "", "set the file extension (optional)")
 	addDurationFlag(uf.FlagSet, &uf.TTL, "ttl", 0, "lifetime of the signed url (optional)")
-	uf.StringVar(&uf.Name, "name", "", "human-readable name for the file, a unique suffix is appended (optional)")
+	uf.StringVar(&uf.Name, "name", "", "human-readable name for the file, must be unique per user (optional)")
 
 	if err := uf.FlagSet.Parse(args); err != nil {
 		return err

--- a/internal/ssh/flags.go
+++ b/internal/ssh/flags.go
@@ -22,6 +22,7 @@ type UploadFlags struct {
 	Private   bool
 	Extension string
 	TTL       time.Duration
+	Name      string
 }
 
 func (uf *UploadFlags) Parse(out io.Writer, args []string) error {
@@ -31,6 +32,7 @@ func (uf *UploadFlags) Parse(out io.Writer, args []string) error {
 	uf.BoolVar(&uf.Private, "private", false, "only accessible via creator or signed urls (optional)")
 	uf.StringVar(&uf.Extension, "ext", "", "set the file extension (optional)")
 	addDurationFlag(uf.FlagSet, &uf.TTL, "ttl", 0, "lifetime of the signed url (optional)")
+	uf.StringVar(&uf.Name, "name", "", "human-readable name for the file, a unique suffix is appended (optional)")
 
 	if err := uf.FlagSet.Parse(args); err != nil {
 		return err
@@ -43,6 +45,21 @@ func (uf *UploadFlags) Parse(out io.Writer, args []string) error {
 	uf.Extension = strings.TrimPrefix(strings.ToLower(uf.Extension), ".")
 
 	return nil
+}
+
+type RenameFlags struct {
+	*flag.FlagSet
+
+	Remove bool
+}
+
+func (rf *RenameFlags) Parse(out io.Writer, args []string) error {
+	rf.FlagSet = flag.NewFlagSet("", flag.ContinueOnError)
+	rf.SetOutput(out)
+
+	rf.BoolVar(&rf.Remove, "rm", false, "remove the file's name")
+
+	return rf.FlagSet.Parse(args)
 }
 
 type SignFlags struct {

--- a/internal/ssh/flags_test.go
+++ b/internal/ssh/flags_test.go
@@ -80,6 +80,13 @@ func TestUploadFlags(t *testing.T) {
 			},
 			err: ssh.ErrFlagRequired,
 		},
+		{
+			name: "name",
+			args: []string{"-name", "deploy-notes"},
+			want: ssh.UploadFlags{
+				Name: "deploy-notes",
+			},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -92,7 +99,40 @@ func TestUploadFlags(t *testing.T) {
 			} else {
 				assert.Equal(t, tc.want.Extension, got.Extension)
 				assert.Equal(t, tc.want.Private, got.Private)
+				assert.Equal(t, tc.want.Name, got.Name)
 			}
+		})
+	}
+}
+
+func TestRenameFlags(t *testing.T) {
+	testcases := []struct {
+		name string
+		args []string
+		want ssh.RenameFlags
+		arg0 string
+	}{
+		{
+			name: "name argument",
+			args: []string{"deploy-notes"},
+			want: ssh.RenameFlags{Remove: false},
+			arg0: "deploy-notes",
+		},
+		{
+			name: "remove",
+			args: []string{"-rm"},
+			want: ssh.RenameFlags{Remove: true},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got ssh.RenameFlags
+			err := got.Parse(io.Discard, tc.args)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want.Remove, got.Remove)
+			assert.Equal(t, tc.arg0, got.Arg(0))
 		})
 	}
 }

--- a/internal/ssh/handler.go
+++ b/internal/ssh/handler.go
@@ -121,27 +121,39 @@ func (h *SessionHandler) Interactive(sesh *UserSession) {
 
 func (h *SessionHandler) FileRequest(sesh *UserSession) {
 	userID := sesh.UserID()
-	fileID := sesh.RequestedFileID()
 
-	file, err := h.DB.FindFile(sesh.Context(), fileID)
+	var (
+		file       *snips.File
+		err        error
+		identifier string
+	)
+
+	if sesh.IsNamedFileRequest() {
+		identifier = sesh.RequestedFileName()
+		file, err = h.DB.FindFileByName(sesh.Context(), userID, identifier)
+	} else {
+		identifier = sesh.RequestedFileID()
+		file, err = h.DB.FindFile(sesh.Context(), identifier)
+	}
+
 	if err != nil {
-		sesh.Error(err, "Unable to get file", "File not found: %s", fileID)
+		sesh.Error(err, "Unable to get file", "File not found: %s", identifier)
 		return
 	}
 
 	if file == nil {
-		sesh.Error(ErrFileNotFound, "Unable to get file", "File not found: %s", fileID)
+		sesh.Error(ErrFileNotFound, "Unable to get file", "File not found: %s", identifier)
 		return
 	}
 
 	if file.Private && file.UserID != userID {
-		sesh.Error(ErrPrivateFileAccess, "Unable to get file", "File not found: %s", fileID)
+		sesh.Error(ErrPrivateFileAccess, "Unable to get file", "File not found: %s", identifier)
 		return
 	}
 
 	if sesh.IsContentUpdate() {
 		if file.UserID != userID {
-			sesh.Error(ErrFileNotFound, "Unable to get file", "File not found: %s", fileID)
+			sesh.Error(ErrFileNotFound, "Unable to get file", "File not found: %s", identifier)
 			return
 		}
 		h.UpdateFileContent(sesh, file)
@@ -155,7 +167,7 @@ func (h *SessionHandler) FileRequest(sesh *UserSession) {
 	}
 
 	if file.UserID != userID {
-		sesh.Error(ErrFileNotFound, "Unable to get file", "File not found: %s", fileID)
+		sesh.Error(ErrFileNotFound, "Unable to get file", "File not found: %s", identifier)
 		return
 	}
 
@@ -164,9 +176,107 @@ func (h *SessionHandler) FileRequest(sesh *UserSession) {
 		h.DeleteFile(sesh, file)
 	case "sign":
 		h.SignFile(sesh, file)
+	case "rename":
+		h.RenameFile(sesh, file)
 	default:
 		sesh.Error(ErrUnknownCommand, "Unknown command", "Unknown command specified: %q", args[0])
 	}
+}
+
+func (h *SessionHandler) RenameFile(sesh *UserSession, file *snips.File) {
+	log := logger.From(sesh.Context())
+
+	flags := RenameFlags{}
+	args := sesh.Command()[1:]
+	if err := flags.Parse(sesh.Stderr(), args); err != nil {
+		if !errors.Is(err, flag.ErrHelp) {
+			log.Warn("invalid user specified flags", "err", err)
+		}
+		return
+	}
+
+	if flags.Remove {
+		if file.Name == "" {
+			noti := Notification{
+				Title: "File Not Renamed ℹ️",
+				Color: styles.Colors.Yellow,
+				WithStyle: func(s *lipgloss.Style) {
+					s.MarginTop(1)
+				},
+			}
+			noti.Messagef("File %q has no name to remove.", file.ID)
+			noti.Render(sesh)
+			return
+		}
+
+		oldName := file.Name
+		file.Name = ""
+		if err := h.DB.UpdateFile(sesh.Context(), file); err != nil {
+			file.Name = oldName
+			sesh.Error(err, "Unable to rename file", "There was an error renaming file: %q", file.ID)
+			return
+		}
+
+		metrics.IncrCounter([]string{"file", "rename"}, 1)
+		log.Info("file name removed", "file_id", file.ID, "old_name", oldName)
+
+		noti := Notification{
+			Color: styles.Colors.Green,
+			Title: "Name Removed 🏷️",
+			WithStyle: func(s *lipgloss.Style) {
+				s.MarginTop(1)
+			},
+		}
+		noti.Messagef("File %q is no longer named %q.", file.ID, oldName)
+		noti.Render(sesh)
+		return
+	}
+
+	name := flags.Arg(0)
+	if name == "" {
+		sesh.Error(ErrNameRequired, "Unable to rename file", "Provide a name (e.g. %q) or remove the current one with -rm.", "rename my-notes")
+		return
+	}
+
+	// ssh joins command words with spaces, so a quoted "two words" name
+	// arrives as extra args — reject instead of silently using the first word
+	if flags.NArg() > 1 {
+		sesh.Error(snips.ErrInvalidName, "Unable to rename file", "%s", snips.ErrInvalidName.Error())
+		return
+	}
+
+	normalized, err := snips.NormalizeName(name)
+	if err != nil {
+		sesh.Error(err, "Unable to rename file", "%s", err.Error())
+		return
+	}
+
+	previous := file.Name
+	file.Name = normalized
+	if err := h.DB.UpdateFile(sesh.Context(), file); err != nil {
+		file.Name = previous
+		if errors.Is(err, db.ErrNameTaken) {
+			sesh.Error(err, "Unable to rename file", "You already have a file named %q.", normalized)
+			return
+		}
+		sesh.Error(err, "Unable to rename file", "There was an error renaming file: %q", file.ID)
+		return
+	}
+
+	metrics.IncrCounter([]string{"file", "rename"}, 1)
+	log.Info("file renamed", "file_id", file.ID, "name", file.Name)
+
+	noti := Notification{
+		Color: styles.Colors.Green,
+		Title: "File Renamed 🏷️",
+		WithStyle: func(s *lipgloss.Style) {
+			s.MarginTop(1)
+		},
+	}
+	noti.Messagef("File %q is now named %q.", file.ID, file.Name)
+	noti.Render(sesh)
+
+	h.renderFileURL(sesh, file)
 }
 
 func (h *SessionHandler) DeleteFile(sesh *UserSession, file *snips.File) {
@@ -323,6 +433,9 @@ func (h *SessionHandler) renderFileResult(sesh *UserSession, file *snips.File, t
 		"size":       styles.C(styles.Colors.White, humanize.Bytes(file.Size)),
 		"visibility": visibility,
 	}
+	if file.Name != "" {
+		kvp["name"] = styles.C(styles.Colors.White, file.Name)
+	}
 	for k, v := range kvp {
 		key := styles.C(styles.Colors.Muted, k+": ")
 		attrs = append(attrs, key+v)
@@ -350,7 +463,11 @@ func (h *SessionHandler) renderFileResult(sesh *UserSession, file *snips.File, t
 }
 
 func (h *SessionHandler) renderFileURL(sesh *UserSession, file *snips.File) {
+	// prefer the human-readable path when the file is named
 	addr := h.Config.HTTPAddressForFile(file.ID)
+	if file.Name != "" {
+		addr = h.Config.HTTPAddressForNamedFile(file.ID, file.Name)
+	}
 	url := lipgloss.NewStyle().
 		Foreground(styles.Colors.Blue).
 		Underline(true).
@@ -497,12 +614,22 @@ func (h *SessionHandler) Upload(sesh *UserSession) {
 		return
 	}
 
+	name := ""
+	if flags.Name != "" {
+		name, err = snips.NormalizeName(flags.Name)
+		if err != nil {
+			sesh.Error(err, "Unable to create file", "Invalid name %q: %s", flags.Name, err.Error())
+			return
+		}
+	}
+
 	size := uint64(len(content))
 	file := snips.File{
 		Private: flags.Private,
 		Size:    size,
 		UserID:  sesh.UserID(),
 		Type:    renderer.DetectFileType(content, flags.Extension, h.Config.EnableGuesser),
+		Name:    name,
 	}
 
 	if err := file.SetContent(content, h.Config.FileCompression); err != nil {
@@ -510,6 +637,10 @@ func (h *SessionHandler) Upload(sesh *UserSession) {
 	}
 
 	if err := h.DB.CreateFile(sesh.Context(), &file, h.Config.Limits.FilesPerUser); err != nil {
+		if errors.Is(err, db.ErrNameTaken) {
+			sesh.Error(err, "Unable to create file", "You already have a file named %q.", name)
+			return
+		}
 		sesh.Error(err, "Unable to create file", "There was an error creating the file: %s", err.Error())
 		return
 	}

--- a/internal/ssh/session.go
+++ b/internal/ssh/session.go
@@ -26,7 +26,11 @@ func (sesh *UserSession) RequestID() string {
 }
 
 func (sesh *UserSession) IsFileRequest() bool {
-	return strings.HasPrefix(sesh.User(), FileRequestPrefix)
+	return strings.HasPrefix(sesh.User(), FileRequestPrefix) || sesh.IsNamedFileRequest()
+}
+
+func (sesh *UserSession) IsNamedFileRequest() bool {
+	return strings.HasPrefix(sesh.User(), NamedFileRequestPrefix)
 }
 
 func (sesh *UserSession) IsContentUpdate() bool {
@@ -37,6 +41,12 @@ func (sesh *UserSession) RequestedFileID() string {
 	id := strings.TrimPrefix(sesh.User(), FileRequestPrefix)
 	id = strings.TrimSuffix(id, ":content")
 	return id
+}
+
+func (sesh *UserSession) RequestedFileName() string {
+	name := strings.TrimPrefix(sesh.User(), NamedFileRequestPrefix)
+	name = strings.TrimSuffix(name, ":content")
+	return name
 }
 
 func (sesh *UserSession) Error(err error, title string, f string, v ...interface{}) {

--- a/internal/tui/views/browser/delegate.go
+++ b/internal/tui/views/browser/delegate.go
@@ -22,7 +22,7 @@ type fileItem struct {
 }
 
 func (i fileItem) Title() string {
-	return i.file.ID
+	return i.file.DisplayName()
 }
 
 func (i fileItem) Description() string {
@@ -39,7 +39,7 @@ func (i fileItem) Description() string {
 }
 
 func (i fileItem) FilterValue() string {
-	return i.file.ID + " " + strings.ToLower(i.file.Type)
+	return i.file.DisplayName() + " " + strings.ToLower(i.file.Type)
 }
 
 func toItems(files []*snips.File) []list.Item {
@@ -92,11 +92,11 @@ func (d fileDelegate) matchHighlight() lipgloss.Style {
 }
 
 // titleMatchIdx filters fuzzy-match positions to those that fall inside the
-// title (file ID) portion of FilterValue.
-func titleMatchIdx(matched []int, id string) []int {
+// title (display name) portion of FilterValue.
+func titleMatchIdx(matched []int, name string) []int {
 	out := make([]int, 0, len(matched))
 	for _, i := range matched {
-		if i < len(id) {
+		if i < len(name) {
 			out = append(out, i)
 		}
 	}
@@ -105,8 +105,8 @@ func titleMatchIdx(matched []int, id string) []int {
 
 // descTypeMatchIdx returns fuzzy-match positions translated to the type span at
 // the start of the description string.
-func descTypeMatchIdx(matched []int, id, typ string) []int {
-	typeStart := len(id) + 1 // skip the space separator in FilterValue
+func descTypeMatchIdx(matched []int, name, typ string) []int {
+	typeStart := len(name) + 1 // skip the space separator in FilterValue
 	typeLen := len(strings.ToLower(typ))
 	out := make([]int, 0, len(matched))
 	for _, i := range matched {
@@ -136,13 +136,13 @@ func (d fileDelegate) itemHint(file *snips.File) string {
 }
 
 func (d fileDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
-	file, ok := item.(fileItem)
+	fileItem, ok := item.(fileItem)
 	if !ok {
 		return
 	}
 
-	title := file.Title()
-	desc := file.Description()
+	title := fileItem.Title()
+	desc := fileItem.Description()
 
 	width := m.Width()
 	if width <= 0 {
@@ -172,15 +172,15 @@ func (d fileDelegate) Render(w io.Writer, m list.Model, index int, item list.Ite
 		title = ansi.Truncate(title, contentWidth, ellipsis)
 		if isFiltered {
 			unmatched := d.styles.SelectedTitle.Inline(true)
-			title = lipgloss.StyleRunes(title, titleMatchIdx(matchedRunes, file.file.ID), d.matchHighlight(), unmatched)
+			title = lipgloss.StyleRunes(title, titleMatchIdx(matchedRunes, fileItem.file.DisplayName()), d.matchHighlight(), unmatched)
 		}
-		hint := d.itemHint(file.file)
+		hint := d.itemHint(fileItem.file)
 		gap := contentWidth - lipgloss.Width(title) - lipgloss.Width(hint)
 		if gap >= 1 {
 			title = title + strings.Repeat(" ", gap) + hint
 		}
 		if isFiltered {
-			descIdx := descTypeMatchIdx(matchedRunes, file.file.ID, file.file.Type)
+			descIdx := descTypeMatchIdx(matchedRunes, fileItem.file.DisplayName(), fileItem.file.Type)
 			if len(descIdx) > 0 {
 				unmatched := d.styles.SelectedDesc.Inline(true)
 				desc = lipgloss.StyleRunes(desc, descIdx, d.matchHighlight(), unmatched)
@@ -188,7 +188,7 @@ func (d fileDelegate) Render(w io.Writer, m list.Model, index int, item list.Ite
 		}
 		// emphasize "private" in red on the highlighted item — safe to embed at
 		// the tail of the description because nothing renders after it
-		if file.file.Private {
+		if fileItem.file.Private {
 			desc = strings.Replace(desc, "private", styles.C(styles.Colors.Red, "private"), 1)
 		}
 		desc = ansi.Truncate(desc, contentWidth, ellipsis)
@@ -199,10 +199,10 @@ func (d fileDelegate) Render(w io.Writer, m list.Model, index int, item list.Ite
 		title = ansi.Truncate(title, contentWidth, ellipsis)
 		if isFiltered {
 			unmatched := d.styles.NormalTitle.Inline(true)
-			title = lipgloss.StyleRunes(title, titleMatchIdx(matchedRunes, file.file.ID), d.matchHighlight(), unmatched)
+			title = lipgloss.StyleRunes(title, titleMatchIdx(matchedRunes, fileItem.file.DisplayName()), d.matchHighlight(), unmatched)
 		}
 		if isFiltered {
-			descIdx := descTypeMatchIdx(matchedRunes, file.file.ID, file.file.Type)
+			descIdx := descTypeMatchIdx(matchedRunes, fileItem.file.DisplayName(), fileItem.file.Type)
 			if len(descIdx) > 0 {
 				unmatched := d.styles.NormalDesc.Inline(true)
 				desc = lipgloss.StyleRunes(desc, descIdx, d.matchHighlight(), unmatched)

--- a/internal/tui/views/code/code.go
+++ b/internal/tui/views/code/code.go
@@ -95,7 +95,7 @@ func (m Code) titleRow() string {
 		humanize.Time(m.file.UpdatedAt),
 	}, " · ")
 
-	return styles.BC(m.theme, m.file.ID) + styles.C(styles.Colors.Muted, " · "+meta)
+	return styles.BC(m.theme, m.file.DisplayName()) + styles.C(styles.Colors.Muted, " · "+meta)
 }
 
 func (m Code) renderContent(file *snips.File) string {

--- a/internal/tui/views/options/options.go
+++ b/internal/tui/views/options/options.go
@@ -216,7 +216,7 @@ func (o Options) renderDetails() string {
 		{"ssh", o.cfg.SSHCommandForFile(file.ID)},
 	}
 	if file.Name != "" {
-		access = append(access, [2]string{"ssh (name)", o.cfg.SSHCommandForNamedFile(file.Name)})
+		access = append(access, [2]string{"", o.cfg.SSHCommandForNamedFile(file.Name)})
 	}
 
 	return styles.Table(

--- a/internal/tui/views/options/options.go
+++ b/internal/tui/views/options/options.go
@@ -29,6 +29,10 @@ type option struct {
 
 var options = []option{
 	{
+		name:   "rename file",
+		prompt: prompt.Rename,
+	},
+	{
 		name:   "edit extension",
 		prompt: prompt.ChangeExtension,
 	},
@@ -182,6 +186,9 @@ func (o Options) renderDetails() string {
 	file := o.file
 
 	rawHTTPAddr := o.cfg.HTTPAddressForFile(file.ID)
+	if file.Name != "" {
+		rawHTTPAddr = o.cfg.HTTPAddressForNamedFile(file.ID, file.Name)
+	}
 	httpAddr := lipgloss.NewStyle().Hyperlink(rawHTTPAddr).Render(rawHTTPAddr)
 	visibility := "public"
 	if file.Private {
@@ -189,8 +196,14 @@ func (o Options) renderDetails() string {
 		visibility = styles.C(styles.Colors.Red, "private")
 	}
 
+	name := styles.C(styles.Colors.Muted, "<none>")
+	if file.Name != "" {
+		name = file.Name
+	}
+
 	values := [][2]string{
 		{"id", file.ID},
+		{"name", name},
 		{"size", humanize.Bytes(file.Size)},
 		{"created", fmt.Sprintf("%s (%s)", file.CreatedAt.Format(time.RFC3339), humanize.Time(file.CreatedAt))},
 		{"modified", fmt.Sprintf("%s (%s)", file.UpdatedAt.Format(time.RFC3339), humanize.Time(file.UpdatedAt))},
@@ -201,6 +214,9 @@ func (o Options) renderDetails() string {
 	access := [][2]string{
 		{"url", httpAddr},
 		{"ssh", o.cfg.SSHCommandForFile(file.ID)},
+	}
+	if file.Name != "" {
+		access = append(access, [2]string{"ssh (name)", o.cfg.SSHCommandForNamedFile(file.Name)})
 	}
 
 	return styles.Table(

--- a/internal/tui/views/prompt/dialog.go
+++ b/internal/tui/views/prompt/dialog.go
@@ -50,6 +50,8 @@ func newDialog(kind Kind, width int) dialog {
 		return newSignedURLDialog()
 	case DeleteFile:
 		return newDeleteDialog()
+	case Rename:
+		return newRenameDialog()
 	default:
 		return nil
 	}

--- a/internal/tui/views/prompt/kind.go
+++ b/internal/tui/views/prompt/kind.go
@@ -8,4 +8,5 @@ const (
 	ChangeVisibility
 	GenerateSignedURL
 	DeleteFile
+	Rename
 )

--- a/internal/tui/views/prompt/rename.go
+++ b/internal/tui/views/prompt/rename.go
@@ -1,0 +1,83 @@
+package prompt
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/armon/go-metrics"
+	"github.com/robherley/snips.sh/internal/db"
+	"github.com/robherley/snips.sh/internal/logger"
+	"github.com/robherley/snips.sh/internal/snips"
+	"github.com/robherley/snips.sh/internal/tui/cmds"
+	"github.com/robherley/snips.sh/internal/tui/feedback"
+)
+
+// renameDialog sets or clears a file's human-readable name.
+type renameDialog struct {
+	textDialog
+}
+
+func newRenameDialog() *renameDialog {
+	return &renameDialog{newTextDialog()}
+}
+
+func (d *renameDialog) title() string {
+	return "rename"
+}
+
+func (d *renameDialog) question(file *snips.File) string {
+	if file.Name != "" {
+		return fmt.Sprintf("What do you want to rename %q to?\n(submit empty to remove the name)", file.Name)
+	}
+	return fmt.Sprintf("What do you want to name %q?", file.ID)
+}
+
+func (d *renameDialog) submit(e env) tea.Cmd {
+	name := strings.TrimSpace(d.value())
+
+	if name == "" {
+		return d.removeName(e)
+	}
+
+	normalized, err := snips.NormalizeName(name)
+	if err != nil {
+		return SetPromptErrorCmd(err)
+	}
+
+	previous := e.file.Name
+	e.file.Name = normalized
+	if err := e.db.UpdateFile(e.ctx, e.file); err != nil {
+		e.file.Name = previous
+		if errors.Is(err, db.ErrNameTaken) {
+			return SetPromptErrorCmd(fmt.Errorf("you already have a file named %q", normalized))
+		}
+		return SetPromptErrorCmd(err)
+	}
+
+	metrics.IncrCounter([]string{"file", "rename"}, 1)
+	logger.From(e.ctx).Info("file renamed", "file", e.file.ID, "name", e.file.Name)
+
+	msg := feedback.Success(fmt.Sprintf("file %q is now named %q", e.file.ID, e.file.Name))
+	return tea.Batch(cmds.ReloadFiles(e.db, e.file.UserID), SetPromptFeedbackCmd(msg, true))
+}
+
+func (d *renameDialog) removeName(e env) tea.Cmd {
+	if e.file.Name == "" {
+		return SetPromptErrorCmd(errors.New("please enter a name"))
+	}
+
+	old := e.file.Name
+	e.file.Name = ""
+	if err := e.db.UpdateFile(e.ctx, e.file); err != nil {
+		e.file.Name = old
+		return SetPromptErrorCmd(err)
+	}
+
+	metrics.IncrCounter([]string{"file", "rename"}, 1)
+	logger.From(e.ctx).Info("file name removed", "file", e.file.ID, "old_name", old)
+
+	msg := feedback.Success(fmt.Sprintf("file %q is no longer named %q", e.file.ID, old))
+	return tea.Batch(cmds.ReloadFiles(e.db, e.file.UserID), SetPromptFeedbackCmd(msg, true))
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -354,13 +354,14 @@ func FileHandler(cfg *config.Config, database db.DB, assets Assets) http.Handler
 			log.Warn("unable to count revisions", "err", err)
 		}
 
-		ogImageURL := fmt.Sprintf("%s://%s/f/%s/og.png", cfg.HTTP.External.Scheme, cfg.HTTP.External.Host, file.ID)
+		path := filePath(r, file)
+		ogImageURL := fmt.Sprintf("%s://%s%s/og.png", cfg.HTTP.External.Scheme, cfg.HTTP.External.Host, path)
 		ogDescription := fmt.Sprintf("%s · %s · %s · %s", file.ID, strings.ToLower(file.Type), humanize.Bytes(file.Size), humanize.Time(file.UpdatedAt))
 
 		vars := map[string]interface{}{
 			"FileID":        file.ID,
 			"FileName":      file.Name,
-			"FilePath":      filePath(r, file),
+			"FilePath":      path,
 			"FileSize":      humanize.Bytes(file.Size),
 			"CreatedAt":     humanize.Time(file.CreatedAt),
 			"UpdatedAt":     humanize.Time(file.UpdatedAt),

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -98,6 +98,7 @@ func LandingHandler(cfg *config.Config, assets Assets) http.HandlerFunc {
 		"HTTPAddr":                 httpAddr,
 		"SSHCommand":               fmt.Sprintf("ssh %s%s", portFlag, sshHost),
 		"SSHCommandForFile":        fmt.Sprintf("ssh %sf:<id>@%s", portFlag, sshHost),
+		"SSHCommandForNamedFile":   fmt.Sprintf("ssh %sn:<name>@%s", portFlag, sshHost),
 		"SSHCommandForFileContent": fmt.Sprintf("ssh %sf:<id>:content@%s", portFlag, sshHost),
 		"CommitSHA":                config.BuildCommit(),
 		"OGImageURL":               httpAddr + "/og.png",
@@ -225,18 +226,47 @@ func DocOGImageHandler(cfg *config.Config, assets Assets) http.HandlerFunc {
 	}
 }
 
+// findFile resolves the {fileID} path segment. When the route carries an
+// /n/{name} segment, it must match the file's name (case-insensitively)
+// or the file is treated as not found, so named links can't be spoofed.
+func findFile(r *http.Request, database db.DB) (*snips.File, error) {
+	fileID := r.PathValue("fileID")
+	if fileID == "" {
+		return nil, nil
+	}
+
+	file, err := database.FindFile(r.Context(), fileID)
+	if err != nil || file == nil {
+		return nil, err
+	}
+
+	if name := r.PathValue("name"); name != "" {
+		if file.Name == "" || !strings.EqualFold(name, file.Name) {
+			return nil, nil
+		}
+	}
+
+	return file, nil
+}
+
+// filePath is the base path the file was requested under: the named variant
+// when the request came in via /n/{name}, otherwise the canonical ID path.
+// Links on the page (raw, revisions) are built from it so navigation stays on
+// the path the visitor arrived on.
+func filePath(r *http.Request, file *snips.File) string {
+	if r.PathValue("name") != "" {
+		return fmt.Sprintf("/f/%s/n/%s", file.ID, file.Name)
+	}
+
+	return fmt.Sprintf("/f/%s", file.ID)
+}
+
 func FileHandler(cfg *config.Config, database db.DB, assets Assets) http.HandlerFunc {
 	signer := signer.New(cfg.HMACKey)
 	return func(w http.ResponseWriter, r *http.Request) {
 		log := logger.From(r.Context())
 
-		fileID := r.PathValue("fileID")
-		if fileID == "" {
-			http.NotFound(w, r)
-			return
-		}
-
-		file, err := database.FindFile(r.Context(), fileID)
+		file, err := findFile(r, database)
 		if err != nil {
 			log.Error("unable to lookup file", "err", err)
 			http.NotFound(w, r)
@@ -329,6 +359,8 @@ func FileHandler(cfg *config.Config, database db.DB, assets Assets) http.Handler
 
 		vars := map[string]interface{}{
 			"FileID":        file.ID,
+			"FileName":      file.Name,
+			"FilePath":      filePath(r, file),
 			"FileSize":      humanize.Bytes(file.Size),
 			"CreatedAt":     humanize.Time(file.CreatedAt),
 			"UpdatedAt":     humanize.Time(file.UpdatedAt),
@@ -393,13 +425,7 @@ func OGImageHandler(cfg *config.Config, database db.DB, assets Assets) http.Hand
 	return func(w http.ResponseWriter, r *http.Request) {
 		log := logger.From(r.Context())
 
-		fileID := r.PathValue("fileID")
-		if fileID == "" {
-			http.NotFound(w, r)
-			return
-		}
-
-		file, err := database.FindFile(r.Context(), fileID)
+		file, err := findFile(r, database)
 		if err != nil {
 			log.Error("unable to lookup file", "err", err)
 			http.NotFound(w, r)
@@ -440,13 +466,7 @@ func RevisionsHandler(cfg *config.Config, database db.DB, assets Assets) http.Ha
 	return func(w http.ResponseWriter, r *http.Request) {
 		log := logger.From(r.Context())
 
-		fileID := r.PathValue("fileID")
-		if fileID == "" {
-			http.NotFound(w, r)
-			return
-		}
-
-		file, err := database.FindFile(r.Context(), fileID)
+		file, err := findFile(r, database)
 		if err != nil {
 			log.Error("unable to lookup file", "err", err)
 			http.NotFound(w, r)
@@ -492,6 +512,7 @@ func RevisionsHandler(cfg *config.Config, database db.DB, assets Assets) http.Ha
 
 		vars := map[string]interface{}{
 			"FileID":       file.ID,
+			"FilePath":     filePath(r, file),
 			"FileSize":     humanize.Bytes(file.Size),
 			"FileType":     strings.ToLower(file.Type),
 			"UpdatedAt":    humanize.Time(file.UpdatedAt),
@@ -515,9 +536,8 @@ func RevisionDiffHandler(cfg *config.Config, database db.DB, assets Assets) http
 	return func(w http.ResponseWriter, r *http.Request) {
 		log := logger.From(r.Context())
 
-		fileID := r.PathValue("fileID")
 		seqStr := r.PathValue("revisionID")
-		if fileID == "" || seqStr == "" {
+		if seqStr == "" {
 			http.NotFound(w, r)
 			return
 		}
@@ -528,7 +548,7 @@ func RevisionDiffHandler(cfg *config.Config, database db.DB, assets Assets) http
 			return
 		}
 
-		file, err := database.FindFile(r.Context(), fileID)
+		file, err := findFile(r, database)
 		if err != nil {
 			log.Error("unable to lookup file", "err", err)
 			http.NotFound(w, r)
@@ -571,6 +591,7 @@ func RevisionDiffHandler(cfg *config.Config, database db.DB, assets Assets) http
 
 		vars := map[string]interface{}{
 			"FileID":           file.ID,
+			"FilePath":         filePath(r, file),
 			"FileSize":         humanize.Bytes(file.Size),
 			"FileType":         strings.ToLower(file.Type),
 			"Private":          file.Private,
@@ -642,6 +663,9 @@ func FileToMarkdown(cfg *config.Config, file *snips.File, content []byte) []byte
 
 	fmt.Fprintf(&buf, "---\n")
 	fmt.Fprintf(&buf, "id: %s\n", file.ID)
+	if file.Name != "" {
+		fmt.Fprintf(&buf, "name: %s\n", file.Name)
+	}
 	fmt.Fprintf(&buf, "size: %s\n", humanize.Bytes(file.Size))
 	fmt.Fprintf(&buf, "type: %s\n", strings.ToLower(file.Type))
 	fmt.Fprintf(&buf, "created: %s\n", file.CreatedAt.UTC().Format(time.RFC3339))

--- a/internal/web/service.go
+++ b/internal/web/service.go
@@ -23,6 +23,10 @@ func New(cfg *config.Config, database db.DB, assets Assets) (*Service, error) {
 	mux.HandleFunc("GET /f/{fileID}/rev", RevisionsHandler(cfg, database, assets))
 	mux.HandleFunc("GET /f/{fileID}/rev/{revisionID}", RevisionDiffHandler(cfg, database, assets))
 	mux.HandleFunc("GET /f/{fileID}/og.png", OGImageHandler(cfg, database, assets))
+	mux.HandleFunc("GET /f/{fileID}/n/{name}", FileHandler(cfg, database, assets))
+	mux.HandleFunc("GET /f/{fileID}/n/{name}/rev", RevisionsHandler(cfg, database, assets))
+	mux.HandleFunc("GET /f/{fileID}/n/{name}/rev/{revisionID}", RevisionDiffHandler(cfg, database, assets))
+	mux.HandleFunc("GET /f/{fileID}/n/{name}/og.png", OGImageHandler(cfg, database, assets))
 	mux.HandleFunc("GET /assets/{asset...}", assets.Serve)
 	mux.HandleFunc("GET /meta.json", MetaHandler(cfg))
 

--- a/internal/web/service_test.go
+++ b/internal/web/service_test.go
@@ -121,6 +121,60 @@ func (suite *HTTPServiceSuite) TestHTTPServer() {
 			},
 		},
 		{
+			name:     "public file via named path",
+			method:   "GET",
+			path:     "/f/eLcyRMrrgP/n/My-Notes",
+			expected: 200,
+			setup: func() {
+				file := testutil.Fixtures.File(suite.T())
+				file.ID = "eLcyRMrrgP"
+				file.Name = "my-notes"
+
+				suite.mockDB.EXPECT().FindFile(mock.Anything, file.ID).Return(&file, nil)
+				suite.mockDB.EXPECT().CountRevisionsByFileID(mock.Anything, file.ID).Return(int64(0), nil)
+			},
+		},
+		{
+			name:     "named path with wrong name",
+			method:   "GET",
+			path:     "/f/wrongname1/n/other-name",
+			expected: 404,
+			setup: func() {
+				file := testutil.Fixtures.File(suite.T())
+				file.ID = "wrongname1"
+				file.Name = "my-notes"
+
+				suite.mockDB.EXPECT().FindFile(mock.Anything, file.ID).Return(&file, nil)
+			},
+		},
+		{
+			name:     "named path for unnamed file",
+			method:   "GET",
+			path:     "/f/unnamed123/n/my-notes",
+			expected: 404,
+			setup: func() {
+				file := testutil.Fixtures.File(suite.T())
+				file.ID = "unnamed123"
+				file.Name = ""
+
+				suite.mockDB.EXPECT().FindFile(mock.Anything, file.ID).Return(&file, nil)
+			},
+		},
+		{
+			name:     "revisions via named path",
+			method:   "GET",
+			path:     "/f/namedrev12/n/my-notes/rev",
+			expected: 200,
+			setup: func() {
+				file := testutil.Fixtures.File(suite.T())
+				file.ID = "namedrev12"
+				file.Name = "my-notes"
+
+				suite.mockDB.EXPECT().FindFile(mock.Anything, file.ID).Return(&file, nil)
+				suite.mockDB.EXPECT().FindRevisionsByFileID(mock.Anything, file.ID).Return(nil, nil)
+			},
+		},
+		{
 			name:     "public file",
 			method:   "GET",
 			path:     "/f/eLcyRMrrgP",

--- a/web/static/css/index.css
+++ b/web/static/css/index.css
@@ -186,7 +186,7 @@ svg.lucide {
   display: flex;
   gap: 1.2rem;
   align-items: center;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .file-header .file-details .file-detail {

--- a/web/static/css/index.css
+++ b/web/static/css/index.css
@@ -186,6 +186,7 @@ svg.lucide {
   display: flex;
   gap: 1.2rem;
   align-items: center;
+  overflow-x: scroll;
 }
 
 .file-header .file-details .file-detail {

--- a/web/static/js/snips.js
+++ b/web/static/js/snips.js
@@ -15,6 +15,7 @@ import {
   KeyRound,
   Package,
   SquarePen,
+  Tag,
   Terminal,
   Zap,
 } from "lucide";
@@ -157,6 +158,7 @@ const initIcons = () => {
       KeyRound,
       Package,
       SquarePen,
+      Tag,
       Terminal,
       Zap,
     },

--- a/web/templates/file.go.html
+++ b/web/templates/file.go.html
@@ -22,6 +22,12 @@
         <i data-lucide="terminal"></i>
         <a href="">{{ .FileID }}</a>
     </div>
+    {{ if .FileName }}
+    <div class="file-detail">
+        <i data-lucide="tag"></i>
+        <a href="/f/{{ .FileID }}/n/{{ .FileName }}">{{ .FileName }}</a>
+    </div>
+    {{ end }}
     <div class="file-detail">
         <i data-lucide="file-code"></i>
         {{ .FileType }}
@@ -76,7 +82,7 @@
     {{ end }} {{ if .RevisionCount }}
     <a
         class="file-action"
-        href="/f/{{ .FileID }}/rev"
+        href="{{ .FilePath }}/rev"
         aria-label="view revision history"
         data-shortcut="h"
     >

--- a/web/templates/landing.go.html
+++ b/web/templates/landing.go.html
@@ -162,6 +162,16 @@
             </div>
         </div>
         <div class="recipe">
+            <p class="muted text-sm">upload (named)</p>
+            <div class="recipe-cmd">
+                <code>echo "content" | {{ .SSHCommand }} -- -name my-notes</code>
+                <button class="recipe-copy" aria-label="copy command">
+                    <i data-lucide="copy"></i>
+                    <i data-lucide="check"></i>
+                </button>
+            </div>
+        </div>
+        <div class="recipe">
             <p class="muted text-sm">download</p>
             <div class="recipe-cmd">
                 <code>{{ .SSHCommandForFile }}</code>
@@ -172,9 +182,39 @@
             </div>
         </div>
         <div class="recipe">
+            <p class="muted text-sm">download (by name)</p>
+            <div class="recipe-cmd">
+                <code>{{ .SSHCommandForNamedFile }}</code>
+                <button class="recipe-copy" aria-label="copy command">
+                    <i data-lucide="copy"></i>
+                    <i data-lucide="check"></i>
+                </button>
+            </div>
+        </div>
+        <div class="recipe">
             <p class="muted text-sm">update</p>
             <div class="recipe-cmd">
                 <code>echo "new" | {{ .SSHCommandForFileContent }}</code>
+                <button class="recipe-copy" aria-label="copy command">
+                    <i data-lucide="copy"></i>
+                    <i data-lucide="check"></i>
+                </button>
+            </div>
+        </div>
+        <div class="recipe">
+            <p class="muted text-sm">rename</p>
+            <div class="recipe-cmd">
+                <code>{{ .SSHCommandForFile }} -- rename my-notes</code>
+                <button class="recipe-copy" aria-label="copy command">
+                    <i data-lucide="copy"></i>
+                    <i data-lucide="check"></i>
+                </button>
+            </div>
+        </div>
+        <div class="recipe">
+            <p class="muted text-sm">remove name</p>
+            <div class="recipe-cmd">
+                <code>{{ .SSHCommandForFile }} -- rename -rm</code>
                 <button class="recipe-copy" aria-label="copy command">
                     <i data-lucide="copy"></i>
                     <i data-lucide="check"></i>

--- a/web/templates/revision.go.html
+++ b/web/templates/revision.go.html
@@ -4,7 +4,7 @@
 <div class="file-details text-sm">
     <div class="file-detail">
         <i data-lucide="terminal"></i>
-        <a href="/f/{{ .FileID }}">{{ .FileID }}</a>
+        <a href="{{ .FilePath }}">{{ .FileID }}</a>
     </div>
     <div class="file-detail">
         <i data-lucide="git-commit-horizontal"></i>

--- a/web/templates/revisions.go.html
+++ b/web/templates/revisions.go.html
@@ -4,14 +4,14 @@
 <div class="file-details text-sm">
     <div class="file-detail">
         <i data-lucide="terminal"></i>
-        <a href="/f/{{ .FileID }}">{{ .FileID }}</a>
+        <a href="{{ .FilePath }}">{{ .FileID }}</a>
     </div>
 </div>
 </nav>
 {{ end }} {{ define "content" }}
 <div class="file-content">
     <div class="revision-list">
-        <a class="revision-item" href="/f/{{ .FileID }}">
+        <a class="revision-item" href="{{ .FilePath }}">
             <div class="revision-item-details">
                 <span class="revision-item-id">
                     <i data-lucide="file-code"></i>
@@ -25,7 +25,7 @@
             <span class="revision-item-time muted"> {{ .UpdatedAt }} </span>
         </a>
         {{ range .Revisions }}
-        <a class="revision-item" href="/f/{{ $.FileID }}/rev/{{ .Sequence }}">
+        <a class="revision-item" href="{{ $.FilePath }}/rev/{{ .Sequence }}">
             <div class="revision-item-details">
                 <span class="revision-item-id">
                     <i data-lucide="git-commit-horizontal"></i>


### PR DESCRIPTION
https://github.com/user-attachments/assets/91a6a0a2-c24f-4883-b397-58e74c5e7b30

On upload (or editing via the TUI/CLI), allow naming to make files more easily discoverable/rememberable.

File names are unique by user, and can be substituted in ssh commands like:

```
ssh f:cqZcmx_IYl@snips.sh
```

Becomes

```
ssh n:main.go@snips.sh
```

40 chars, alphanumeric and can contain `.`, `-` or `_`
