### PR TITLE
feat(api): add REST API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/mattn/go-isatty v0.0.22
 	github.com/mattn/go-sqlite3 v1.14.47
 	github.com/microcosm-cc/bluemonday v1.0.27
-	github.com/muesli/reflow v0.3.0
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/pressly/goose/v3 v3.27.2
 	github.com/robherley/magika-go v0.1.0
@@ -31,6 +30,7 @@ require (
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20220924101305-151362477c87
 	golang.org/x/crypto v0.54.0
 	golang.org/x/image v0.44.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -76,5 +76,4 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -138,7 +138,6 @@ github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW
 github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw4=
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
-github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
 github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mattn/go-sqlite3 v1.14.47 h1:jOBI62gS7nKeZv+as1oGEy0+1qISgXwH/QBlR6KbfIo=
@@ -154,8 +153,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
-github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
-github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
@@ -180,8 +177,6 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
-github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/robherley/magika-go v0.1.0 h1:mP+DS0PEPMTUfc4eXuCwkR3BvSAJhSbDsvT7KLXsnno=

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -1,0 +1,372 @@
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/robherley/snips.sh/internal/config"
+	"github.com/robherley/snips.sh/internal/db"
+	"github.com/robherley/snips.sh/internal/snips"
+	"github.com/robherley/snips.sh/internal/web"
+	"github.com/stretchr/testify/suite"
+)
+
+type apiClient struct {
+	suite      *APIIntegrationSuite
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+	createdIDs []string
+}
+
+type file struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Size    uint64 `json:"size"`
+	Private bool   `json:"private"`
+	Type    string `json:"type"`
+}
+
+type filesPage struct {
+	Files      []file `json:"files"`
+	NextCursor string `json:"next_cursor"`
+}
+
+type revision struct {
+	Sequence int64  `json:"sequence"`
+	Diff     string `json:"diff"`
+}
+
+type revisionsPage struct {
+	Revisions  []revision `json:"revisions"`
+	NextCursor string     `json:"next_cursor"`
+}
+
+type APIIntegrationSuite struct {
+	suite.Suite
+	client *apiClient
+}
+
+func TestAPIIntegrationSuite(t *testing.T) {
+	suite.Run(t, new(APIIntegrationSuite))
+}
+
+func (s *APIIntegrationSuite) SetupTest() {
+	s.client = newAPIClient(s)
+	s.T().Cleanup(s.client.cleanup)
+}
+
+//nolint:gocyclo // Subtest assertions are intentionally kept beside each flow.
+func (s *APIIntegrationSuite) TestAPIEndToEnd() {
+	c := s.client
+
+	s.T().Logf("running against %s", c.baseURL)
+	runID := fmt.Sprintf("%d", time.Now().UnixNano())
+	publicName := "e2e-" + runID + "-public"
+	privateName := "e2e-" + runID + "-private"
+	renamedName := "e2e-" + runID + "-renamed"
+	publicContent := []byte("snips e2e public " + runID + "\n")
+	privateContent := []byte("snips e2e private " + runID + "\n")
+	updatedContent := []byte("# Updated by snips e2e\n\nRun: " + runID + "\n")
+	var publicFile, privateFile file
+
+	s.Run("discovery and authentication", func() {
+		status, body := c.request(http.MethodGet, c.baseURL+"/openapi.json", nil, "", false)
+		requireStatus(s, http.StatusOK, status, body)
+		var spec struct {
+			OpenAPI string                     `json:"openapi"`
+			Paths   map[string]json.RawMessage `json:"paths"`
+		}
+		decodeJSON(s, body, &spec)
+		s.Require().NotEmpty(spec.OpenAPI)
+		s.Require().Contains(spec.Paths, "/files")
+		s.Require().Contains(spec.Paths, "/files/{id}/sign")
+
+		status, body = c.apiRequest(http.MethodGet, "/meta", nil, "", false)
+		requireStatus(s, http.StatusOK, status, body)
+		var metadata struct {
+			Limits struct {
+				FileSize struct {
+					Bytes uint64 `json:"bytes"`
+				} `json:"file_size"`
+				FilesPerUser uint64 `json:"files_per_user"`
+			} `json:"limits"`
+			Endpoints struct {
+				HTTP string `json:"http"`
+			} `json:"endpoints"`
+		}
+		decodeJSON(s, body, &metadata)
+		s.Require().NotZero(metadata.Limits.FileSize.Bytes)
+		s.Require().NotZero(metadata.Limits.FilesPerUser)
+		s.Require().NotEmpty(metadata.Endpoints.HTTP)
+
+		status, body = c.apiRequest(http.MethodGet, "/user", nil, "", false)
+		requireStatus(s, http.StatusUnauthorized, status, body)
+		status, body = c.apiRequest(http.MethodGet, "/user", nil, "", true)
+		requireStatus(s, http.StatusOK, status, body)
+		var user struct {
+			ID        string `json:"id"`
+			CreatedAt string `json:"created_at"`
+		}
+		decodeJSON(s, body, &user)
+		s.Require().NotEmpty(user.ID)
+		s.Require().NotEmpty(user.CreatedAt)
+	})
+
+	s.Run("create public and private files", func() {
+		publicFile = c.createFile(publicName, false, "txt", publicContent)
+		s.Require().Equal(publicName, publicFile.Name)
+		s.Require().False(publicFile.Private)
+		s.Require().Equal(uint64(len(publicContent)), publicFile.Size)
+
+		privateFile = c.createFile(privateName, true, "txt", privateContent)
+		s.Require().Equal(privateName, privateFile.Name)
+		s.Require().True(privateFile.Private)
+	})
+
+	s.Run("filter and paginate files", func() {
+		query := url.Values{"name": {publicName}}
+		status, body := c.apiRequest(http.MethodGet, "/files?"+query.Encode(), nil, "", true)
+		requireStatus(s, http.StatusOK, status, body)
+		var namedFiles filesPage
+		decodeJSON(s, body, &namedFiles)
+		s.Require().Len(namedFiles.Files, 1)
+		s.Require().Equal(publicFile.ID, namedFiles.Files[0].ID)
+
+		status, body = c.apiRequest(http.MethodGet, "/files?limit=1", nil, "", true)
+		requireStatus(s, http.StatusOK, status, body)
+		var firstPage filesPage
+		decodeJSON(s, body, &firstPage)
+		s.Require().Len(firstPage.Files, 1)
+		s.Require().NotEmpty(firstPage.NextCursor)
+
+		query = url.Values{"limit": {"1"}, "cursor": {firstPage.NextCursor}}
+		status, body = c.apiRequest(http.MethodGet, "/files?"+query.Encode(), nil, "", true)
+		requireStatus(s, http.StatusOK, status, body)
+		var secondPage filesPage
+		decodeJSON(s, body, &secondPage)
+		s.Require().Len(secondPage.Files, 1)
+	})
+
+	s.Run("download file metadata and content", func() {
+		status, body := c.apiRequest(http.MethodGet, "/files/"+publicFile.ID, nil, "", true)
+		requireStatus(s, http.StatusOK, status, body)
+		var fetched file
+		decodeJSON(s, body, &fetched)
+		s.Require().Equal(publicFile.ID, fetched.ID)
+		s.Require().False(fetched.Private)
+
+		status, body = c.apiRequest(http.MethodGet, "/files/"+publicFile.ID+"/content", nil, "", true)
+		requireStatus(s, http.StatusOK, status, body)
+		s.Require().Equal(publicContent, body)
+	})
+
+	s.Run("update metadata and content", func() {
+		patch := marshalJSON(s, map[string]any{
+			"name":    renamedName,
+			"private": true,
+			"type":    "md",
+		})
+		status, body := c.apiRequest(http.MethodPatch, "/files/"+publicFile.ID, patch, "application/json", true)
+		requireStatus(s, http.StatusOK, status, body)
+		var updated file
+		decodeJSON(s, body, &updated)
+		s.Require().Equal(renamedName, updated.Name)
+		s.Require().True(updated.Private)
+		s.Require().Equal("markdown", updated.Type)
+
+		status, body = c.apiRequest(http.MethodPut, "/files/"+publicFile.ID+"/content?ext=md", updatedContent, "application/octet-stream", true)
+		requireStatus(s, http.StatusOK, status, body)
+		decodeJSON(s, body, &updated)
+		s.Require().Equal(uint64(len(updatedContent)), updated.Size)
+		s.Require().Equal("markdown", updated.Type)
+
+		status, body = c.apiRequest(http.MethodGet, "/files/"+publicFile.ID+"/content", nil, "", true)
+		requireStatus(s, http.StatusOK, status, body)
+		s.Require().Equal(updatedContent, body)
+	})
+
+	s.Run("list and fetch revisions", func() {
+		status, body := c.apiRequest(http.MethodGet, "/files/"+publicFile.ID+"/revisions?limit=1", nil, "", true)
+		requireStatus(s, http.StatusOK, status, body)
+		var revisionList revisionsPage
+		decodeJSON(s, body, &revisionList)
+		s.Require().Len(revisionList.Revisions, 1)
+		s.Require().GreaterOrEqual(revisionList.Revisions[0].Sequence, int64(1))
+
+		sequence := revisionList.Revisions[0].Sequence
+		status, body = c.apiRequest(http.MethodGet, fmt.Sprintf("/files/%s/revisions/%d", publicFile.ID, sequence), nil, "", true)
+		requireStatus(s, http.StatusOK, status, body)
+		var fetchedRevision revision
+		decodeJSON(s, body, &fetchedRevision)
+		s.Require().Equal(sequence, fetchedRevision.Sequence)
+		s.Require().NotEmpty(fetchedRevision.Diff)
+	})
+
+	s.Run("sign and access private file", func() {
+		signRequest := marshalJSON(s, map[string]int{"ttl_seconds": 300})
+		status, body := c.apiRequest(http.MethodPost, "/files/"+publicFile.ID+"/sign", signRequest, "application/json", true)
+		requireStatus(s, http.StatusCreated, status, body)
+		var signed struct {
+			URL       string `json:"url"`
+			ExpiresAt string `json:"expires_at"`
+		}
+		decodeJSON(s, body, &signed)
+		s.Require().NotEmpty(signed.URL)
+		s.Require().NotEmpty(signed.ExpiresAt)
+		s.Require().Contains(signed.URL, "sig=")
+
+		status, body = c.request(http.MethodGet, c.baseURL+"/f/"+publicFile.ID+"?r=1", nil, "", false)
+		requireStatus(s, http.StatusNotFound, status, body)
+		status, body = c.request(http.MethodGet, signed.URL, nil, "", false)
+		requireStatus(s, http.StatusOK, status, body)
+		s.Require().Equal(updatedContent, body)
+	})
+
+	s.Run("delete files", func() {
+		c.deleteFile(privateFile.ID)
+		status, body := c.apiRequest(http.MethodGet, "/files/"+privateFile.ID, nil, "", true)
+		requireStatus(s, http.StatusNotFound, status, body)
+
+		c.deleteFile(publicFile.ID)
+		status, body = c.apiRequest(http.MethodGet, "/files/"+publicFile.ID, nil, "", true)
+		requireStatus(s, http.StatusNotFound, status, body)
+	})
+}
+
+func newAPIClient(s *APIIntegrationSuite) *apiClient {
+	s.T().Helper()
+
+	cfg, err := config.Load()
+	s.Require().NoError(err)
+	cfg.EnableGuesser = false
+
+	database, err := db.NewSqlite(s.T().TempDir() + "/snips.db")
+	s.Require().NoError(err)
+	s.T().Cleanup(func() {
+		if closer, ok := database.(interface{ Close() error }); ok {
+			s.Assert().NoError(closer.Close())
+		}
+	})
+
+	s.Require().NoError(database.Migrate(s.T().Context()))
+	user, err := database.CreateUserWithPublicKey(s.T().Context(), &snips.PublicKey{
+		Fingerprint: "SHA256:snips-api-integration-test",
+		Type:        "ssh-ed25519",
+	})
+	s.Require().NoError(err)
+
+	token, tokenHash, err := snips.NewAPIKeyToken()
+	s.Require().NoError(err)
+	s.Require().NoError(database.CreateAPIKey(s.T().Context(), &snips.APIKey{
+		Name:      "integration-test",
+		TokenHash: tokenHash,
+		UserID:    user.ID,
+	}, cfg.Limits.APIKeysPerUser))
+
+	mux := http.NewServeMux()
+	web.NewAPI(cfg, database).Register(mux)
+	// Raw signed-file access is part of the API signing flow.
+	mux.HandleFunc("GET /f/{fileID}", web.FileHandler(cfg, database, nil))
+	server := httptest.NewServer(web.WithMiddleware(mux))
+	s.T().Cleanup(server.Close)
+
+	externalURL, err := url.Parse(server.URL)
+	s.Require().NoError(err)
+	cfg.HTTP.External = *externalURL
+
+	return &apiClient{
+		suite:      s,
+		baseURL:    server.URL,
+		apiKey:     token,
+		httpClient: server.Client(),
+	}
+}
+
+func (c *apiClient) createFile(name string, private bool, extension string, content []byte) file {
+	c.suite.T().Helper()
+	query := url.Values{
+		"name":    {name},
+		"private": {fmt.Sprintf("%t", private)},
+		"ext":     {extension},
+	}
+	status, body := c.apiRequest(http.MethodPost, "/files?"+query.Encode(), content, "application/octet-stream", true)
+	requireStatus(c.suite, http.StatusCreated, status, body)
+
+	var created file
+	decodeJSON(c.suite, body, &created)
+	c.suite.Require().NotEmpty(created.ID)
+	c.createdIDs = append(c.createdIDs, created.ID)
+	return created
+}
+
+func (c *apiClient) deleteFile(id string) {
+	c.suite.T().Helper()
+	status, body := c.apiRequest(http.MethodDelete, "/files/"+id, nil, "", true)
+	requireStatus(c.suite, http.StatusNoContent, status, body)
+	for i, createdID := range c.createdIDs {
+		if createdID == id {
+			c.createdIDs = append(c.createdIDs[:i], c.createdIDs[i+1:]...)
+			return
+		}
+	}
+}
+
+func (c *apiClient) cleanup() {
+	for i := len(c.createdIDs) - 1; i >= 0; i-- {
+		id := c.createdIDs[i]
+		status, body := c.apiRequest(http.MethodDelete, "/files/"+id, nil, "", true)
+		c.suite.Assert().Contains([]int{http.StatusNoContent, http.StatusNotFound}, status, "cleanup file %s: %s", id, body)
+	}
+}
+
+func (c *apiClient) apiRequest(method, path string, body []byte, contentType string, authenticated bool) (int, []byte) {
+	c.suite.T().Helper()
+	return c.request(method, c.baseURL+"/api/v1"+path, body, contentType, authenticated)
+}
+
+func (c *apiClient) request(method, requestURL string, body []byte, contentType string, authenticated bool) (int, []byte) {
+	c.suite.T().Helper()
+	req, err := http.NewRequest(method, requestURL, bytes.NewReader(body))
+	c.suite.Require().NoError(err)
+	if authenticated {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	// The web endpoint returns raw content to curl clients.
+	req.Header.Set("User-Agent", "curl/snips-integration-test")
+
+	res, err := c.httpClient.Do(req)
+	c.suite.Require().NoError(err, "%s %s", method, requestURL)
+	defer res.Body.Close()
+
+	responseBody, err := io.ReadAll(res.Body)
+	c.suite.Require().NoError(err)
+	return res.StatusCode, responseBody
+}
+
+func requireStatus(s *APIIntegrationSuite, expected, actual int, body []byte) {
+	s.T().Helper()
+	s.Require().Equal(expected, actual, "response body: %s", body)
+}
+
+func decodeJSON(s *APIIntegrationSuite, data []byte, target any) {
+	s.T().Helper()
+	s.Require().NoError(json.Unmarshal(data, target), "response body: %s", data)
+}
+
+func marshalJSON(s *APIIntegrationSuite, value any) []byte {
+	s.T().Helper()
+	data, err := json.Marshal(value)
+	s.Require().NoError(err)
+	return data
+}

--- a/internal/snips/file.go
+++ b/internal/snips/file.go
@@ -16,15 +16,15 @@ const (
 )
 
 type File struct {
-	ID         string
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
-	Size       uint64
-	RawContent []byte
-	Private    bool
-	Type       string
-	UserID     string
-	Name       string
+	ID         string    `json:"id"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	Size       uint64    `json:"size"`
+	RawContent []byte    `json:"-"`
+	Private    bool      `json:"private"`
+	Type       string    `json:"type"`
+	UserID     string    `json:"-"`
+	Name       string    `json:"name,omitempty"`
 }
 
 func (f *File) DisplayName() string {

--- a/internal/snips/revision.go
+++ b/internal/snips/revision.go
@@ -7,13 +7,13 @@ import (
 )
 
 type Revision struct {
-	ID        string
-	Sequence  int64
-	FileID    string
-	CreatedAt time.Time
-	RawDiff   []byte // may be zstd-compressed
-	Size      uint64 // file size after this revision
-	Type      string // file type after this revision
+	ID        string    `json:"id"`
+	Sequence  int64     `json:"sequence"`
+	FileID    string    `json:"-"`
+	CreatedAt time.Time `json:"created_at"`
+	RawDiff   []byte    `json:"-"`    // may be zstd-compressed
+	Size      uint64    `json:"size"` // file size after this revision
+	Type      string    `json:"type"` // file type after this revision
 }
 
 func (r *Revision) GetDiff() ([]byte, error) {

--- a/internal/snips/user.go
+++ b/internal/snips/user.go
@@ -3,8 +3,8 @@ package snips
 import "time"
 
 type User struct {
-	ID         string
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
-	ThemeColor string // named theme option from styles.ThemeOptions (e.g. "blue"); empty = use default palette
+	ID         string    `json:"id"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	ThemeColor string    `json:"-"`
 }

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -24,8 +24,9 @@ import (
 )
 
 const (
-	APIDefaultPageSize = 50
-	APIMaxPageSize     = 100
+	APIDefaultPageSize         = 50
+	APIMaxPageSize             = 100
+	APIMaxSignTTLSeconds int64 = (1<<63 - 1) / int64(time.Second)
 )
 
 var (
@@ -594,8 +595,8 @@ func (a *API) SignFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if body.TTLSeconds < 1 {
-		http.Error(w, "ttl_seconds must be a positive integer", http.StatusBadRequest)
+	if body.TTLSeconds < 1 || body.TTLSeconds > APIMaxSignTTLSeconds {
+		http.Error(w, fmt.Sprintf("ttl_seconds must be between 1 and %d", APIMaxSignTTLSeconds), http.StatusBadRequest)
 		return
 	}
 

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1,0 +1,611 @@
+package web
+
+import (
+	_ "embed"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/armon/go-metrics"
+	"github.com/dustin/go-humanize"
+	"github.com/robherley/snips.sh/internal/config"
+	"github.com/robherley/snips.sh/internal/db"
+	"github.com/robherley/snips.sh/internal/files"
+	"github.com/robherley/snips.sh/internal/logger"
+	"github.com/robherley/snips.sh/internal/renderer"
+	"github.com/robherley/snips.sh/internal/snips"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	APIDefaultPageSize = 50
+	APIMaxPageSize     = 100
+)
+
+var (
+	//go:embed openapi.yaml
+	openapiYAML []byte
+	// converted at init: a broken spec fails immediately, and is caught by tests
+	openapiJSON = mustYAMLToJSON(openapiYAML)
+)
+
+var (
+	errAPIContentTooLarge = errors.New("content too large")
+	errAPIContentEmpty    = errors.New("content empty")
+)
+
+type API struct {
+	cfg *config.Config
+	db  db.DB
+}
+
+func NewAPI(cfg *config.Config, database db.DB) *API {
+	return &API{cfg: cfg, db: database}
+}
+
+func (a *API) Register(mux *http.ServeMux) {
+	authed := func(next http.HandlerFunc) http.HandlerFunc {
+		return WithAuthentication(a.db, next)
+	}
+
+	mux.Handle("GET /meta.json", http.RedirectHandler("/api/v1/meta", http.StatusMovedPermanently))
+
+	mux.HandleFunc("GET /openapi.json", a.OpenAPI)
+	mux.HandleFunc("GET /openapi.yaml", a.OpenAPI)
+	mux.HandleFunc("GET /openapi.yml", a.OpenAPI)
+
+	mux.HandleFunc("GET /api/v1/meta", a.Meta)
+	mux.HandleFunc("GET /api/v1/user", authed(a.User))
+	mux.HandleFunc("GET /api/v1/files", authed(a.ListFiles))
+	mux.HandleFunc("POST /api/v1/files", authed(a.CreateFile))
+	mux.HandleFunc("GET /api/v1/files/{fileID}", authed(a.GetFile))
+	mux.HandleFunc("PATCH /api/v1/files/{fileID}", authed(a.UpdateFile))
+	mux.HandleFunc("DELETE /api/v1/files/{fileID}", authed(a.DeleteFile))
+	mux.HandleFunc("GET /api/v1/files/{fileID}/content", authed(a.GetFileContent))
+	mux.HandleFunc("PUT /api/v1/files/{fileID}/content", authed(a.UpdateFileContent))
+	mux.HandleFunc("GET /api/v1/files/{fileID}/revisions", authed(a.ListRevisions))
+	mux.HandleFunc("GET /api/v1/files/{fileID}/revisions/{sequence}", authed(a.GetRevision))
+	mux.HandleFunc("POST /api/v1/files/{fileID}/sign", authed(a.SignFile))
+}
+
+func mustYAMLToJSON(in []byte) []byte {
+	var doc any
+	if err := yaml.Unmarshal(in, &doc); err != nil {
+		panic(fmt.Sprintf("invalid openapi spec: %v", err))
+	}
+
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		panic(fmt.Sprintf("invalid openapi spec: %v", err))
+	}
+
+	return out
+}
+
+// OpenAPI serves the specification as json or yaml, based on the extension.
+func (a *API) OpenAPI(w http.ResponseWriter, r *http.Request) {
+	if strings.HasSuffix(r.URL.Path, ".json") {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(openapiJSON)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = w.Write(openapiYAML)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}
+
+// findFile resolves {fileID} and enforces visibility: a file that doesn't
+// exist is a 404, and so is another user's file when it's private (or when
+// the operation is owner-only), so existence isn't leaked.
+func (a *API) findFile(w http.ResponseWriter, r *http.Request, ownerOnly bool) *snips.File {
+	file, err := a.db.FindFile(r.Context(), r.PathValue("fileID"))
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return nil
+	}
+
+	userID, _ := UserID(r.Context())
+	if file == nil || (file.UserID != userID && (ownerOnly || file.Private)) {
+		http.Error(w, "file not found", http.StatusNotFound)
+		return nil
+	}
+
+	return file
+}
+
+// readContent reads the raw request body, enforcing the file size limit.
+func (a *API) readContent(r *http.Request) ([]byte, error) {
+	maxSize := a.cfg.Limits.FileSize
+
+	content, err := io.ReadAll(io.LimitReader(r.Body, int64(maxSize)+1))
+	if err != nil {
+		return nil, err
+	}
+
+	if uint64(len(content)) > maxSize {
+		return nil, errAPIContentTooLarge
+	}
+
+	if len(content) == 0 {
+		return nil, errAPIContentEmpty
+	}
+
+	return content, nil
+}
+
+// pageSize parses the limit query parameter, reporting failure with a 400.
+func pageSize(w http.ResponseWriter, r *http.Request) (uint64, bool) {
+	raw := r.URL.Query().Get("limit")
+	if raw == "" {
+		return APIDefaultPageSize, true
+	}
+
+	limit, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil || limit < 1 || limit > APIMaxPageSize {
+		http.Error(w, "limit must be an integer between 1 and "+strconv.Itoa(APIMaxPageSize), http.StatusBadRequest)
+		return 0, false
+	}
+
+	return limit, true
+}
+
+// cursors are opaque so the pagination scheme can change without breaking
+// clients; today they are just the base64-encoded row offset of the next page
+func encodeCursor(offset uint64) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(strconv.FormatUint(offset, 10)))
+}
+
+func decodeCursor(w http.ResponseWriter, r *http.Request) (uint64, bool) {
+	cursor := r.URL.Query().Get("cursor")
+	if cursor == "" {
+		return 0, true
+	}
+
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		http.Error(w, "invalid cursor", http.StatusBadRequest)
+		return 0, false
+	}
+
+	offset, err := strconv.ParseUint(string(raw), 10, 64)
+	if err != nil {
+		http.Error(w, "invalid cursor", http.StatusBadRequest)
+		return 0, false
+	}
+
+	return offset, true
+}
+
+func (a *API) Meta(w http.ResponseWriter, r *http.Request) {
+	metadata := map[string]any{
+		"limits": map[string]any{
+			"file_size": map[string]any{
+				"bytes": a.cfg.Limits.FileSize,
+				"human": humanize.Bytes(a.cfg.Limits.FileSize),
+			},
+			"files_per_user":     a.cfg.Limits.FilesPerUser,
+			"revisions_per_file": a.cfg.Limits.RevisionsPerFile,
+			"api_keys_per_user":  a.cfg.Limits.APIKeysPerUser,
+			"session_duration": map[string]any{
+				"seconds": a.cfg.Limits.SessionDuration.Seconds(),
+				"human":   a.cfg.Limits.SessionDuration.String(),
+			},
+		},
+		"endpoints": map[string]any{
+			"http": a.cfg.HTTP.External.String(),
+			"ssh":  a.cfg.SSH.External.String(),
+		},
+		"commit_sha":      config.BuildCommit(),
+		"guesser_enabled": a.cfg.EnableGuesser,
+	}
+
+	writeJSON(w, http.StatusOK, metadata)
+}
+
+func (a *API) User(w http.ResponseWriter, r *http.Request) {
+	userID, _ := UserID(r.Context())
+
+	user, err := a.db.FindUser(r.Context(), userID)
+	if err != nil || user == nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, user)
+}
+
+func (a *API) ListFiles(w http.ResponseWriter, r *http.Request) {
+	type response struct {
+		Files      []*snips.File `json:"files"`
+		NextCursor string        `json:"next_cursor,omitempty"`
+	}
+
+	userID, _ := UserID(r.Context())
+
+	// names are unique per user, so a name filter returns at most one file
+	if name := r.URL.Query().Get("name"); name != "" {
+		file, err := a.db.FindFileByName(r.Context(), userID, name)
+		if err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		matches := []*snips.File{}
+		if file != nil {
+			matches = append(matches, file)
+		}
+
+		writeJSON(w, http.StatusOK, response{Files: matches})
+		return
+	}
+
+	limit, ok := pageSize(w, r)
+	if !ok {
+		return
+	}
+
+	offset, ok := decodeCursor(w, r)
+	if !ok {
+		return
+	}
+
+	// fetch one extra row to learn whether another page exists
+	userFiles, err := a.db.FindFilesByUser(r.Context(), userID, db.WithLimit(limit+1), db.WithOffset(offset))
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	resp := response{Files: userFiles}
+	if uint64(len(userFiles)) > limit {
+		resp.Files = userFiles[:limit]
+		resp.NextCursor = encodeCursor(offset + limit)
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (a *API) CreateFile(w http.ResponseWriter, r *http.Request) {
+	content, err := a.readContent(r)
+	if err != nil {
+		switch {
+		case errors.Is(err, errAPIContentTooLarge):
+			http.Error(w, "content exceeds the file size limit", http.StatusRequestEntityTooLarge)
+		case errors.Is(err, errAPIContentEmpty):
+			http.Error(w, "content is empty", http.StatusBadRequest)
+		default:
+			http.Error(w, "unable to read content", http.StatusBadRequest)
+		}
+		return
+	}
+
+	query := r.URL.Query()
+
+	name := ""
+	if rawName := query.Get("name"); rawName != "" {
+		name, err = snips.NormalizeName(rawName)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
+	private := false
+	if rawPrivate := query.Get("private"); rawPrivate != "" {
+		private, err = strconv.ParseBool(rawPrivate)
+		if err != nil {
+			http.Error(w, "private must be a boolean", http.StatusBadRequest)
+			return
+		}
+	}
+
+	userID, _ := UserID(r.Context())
+	file := &snips.File{
+		Private: private,
+		Size:    uint64(len(content)),
+		UserID:  userID,
+		Type:    renderer.DetectFileType(content, query.Get("ext"), a.cfg.EnableGuesser),
+		Name:    name,
+	}
+
+	if err := file.SetContent(content, a.cfg.FileCompression); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if err := a.db.CreateFile(r.Context(), file, a.cfg.Limits.FilesPerUser); err != nil {
+		switch {
+		case errors.Is(err, db.ErrNameTaken):
+			http.Error(w, "you already have a file with that name", http.StatusConflict)
+		case errors.Is(err, db.ErrFileLimit):
+			http.Error(w, "file limit reached", http.StatusUnprocessableEntity)
+		default:
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	metrics.IncrCounterWithLabels([]string{"file", "create"}, 1, []metrics.Label{
+		{Name: "private", Value: strconv.FormatBool(file.Private)},
+		{Name: "type", Value: file.Type},
+	})
+	logger.From(r.Context()).Info("file uploaded", "file_id", file.ID, "user_id", file.UserID, "size", file.Size, "private", file.Private, "file_type", file.Type)
+
+	writeJSON(w, http.StatusCreated, file)
+}
+
+func (a *API) GetFile(w http.ResponseWriter, r *http.Request) {
+	file := a.findFile(w, r, false)
+	if file == nil {
+		return
+	}
+
+	writeJSON(w, http.StatusOK, file)
+}
+
+func (a *API) UpdateFile(w http.ResponseWriter, r *http.Request) {
+	file := a.findFile(w, r, true)
+	if file == nil {
+		return
+	}
+
+	var patch struct {
+		Name    *string `json:"name"`
+		Private *bool   `json:"private"`
+		Type    *string `json:"type"`
+	}
+
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&patch); err != nil {
+		http.Error(w, "invalid json body", http.StatusBadRequest)
+		return
+	}
+
+	if patch.Name == nil && patch.Private == nil && patch.Type == nil {
+		http.Error(w, "nothing to update: provide name, private, and/or type", http.StatusBadRequest)
+		return
+	}
+
+	if patch.Name != nil {
+		// an empty name removes it
+		name := ""
+		if *patch.Name != "" {
+			var err error
+			name, err = snips.NormalizeName(*patch.Name)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+		}
+		file.Name = name
+	}
+
+	if patch.Private != nil {
+		file.Private = *patch.Private
+	}
+
+	if patch.Type != nil {
+		extension := strings.TrimSpace(*patch.Type)
+		if extension == "" {
+			http.Error(w, "type cannot be empty", http.StatusBadRequest)
+			return
+		}
+
+		content, err := file.GetContent()
+		if err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		file.Type = renderer.DetectFileType(content, extension, a.cfg.EnableGuesser)
+	}
+
+	if err := a.db.UpdateFile(r.Context(), file); err != nil {
+		if errors.Is(err, db.ErrNameTaken) {
+			http.Error(w, "you already have a file with that name", http.StatusConflict)
+			return
+		}
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	metrics.IncrCounter([]string{"file", "update"}, 1)
+	logger.From(r.Context()).Info("file updated", "file_id", file.ID, "user_id", file.UserID)
+
+	writeJSON(w, http.StatusOK, file)
+}
+
+func (a *API) DeleteFile(w http.ResponseWriter, r *http.Request) {
+	file := a.findFile(w, r, true)
+	if file == nil {
+		return
+	}
+
+	if err := a.db.DeleteFile(r.Context(), file.ID); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	metrics.IncrCounter([]string{"file", "delete"}, 1)
+	logger.From(r.Context()).Info("file deleted", "file_id", file.ID, "user_id", file.UserID)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (a *API) GetFileContent(w http.ResponseWriter, r *http.Request) {
+	file := a.findFile(w, r, false)
+	if file == nil {
+		return
+	}
+
+	content, err := file.GetContent()
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	contentType := "text/plain; charset=utf-8"
+	if file.IsBinary() {
+		contentType = "application/octet-stream"
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	_, _ = w.Write(content)
+}
+
+func (a *API) UpdateFileContent(w http.ResponseWriter, r *http.Request) {
+	file := a.findFile(w, r, true)
+	if file == nil {
+		return
+	}
+
+	content, err := a.readContent(r)
+	if err != nil {
+		switch {
+		case errors.Is(err, errAPIContentTooLarge):
+			http.Error(w, "content exceeds the file size limit", http.StatusRequestEntityTooLarge)
+		case errors.Is(err, errAPIContentEmpty):
+			http.Error(w, "content is empty", http.StatusBadRequest)
+		default:
+			http.Error(w, "unable to read content", http.StatusBadRequest)
+		}
+		return
+	}
+
+	if err := files.UpdateContent(r.Context(), a.db, a.cfg, file, content, r.URL.Query().Get("ext")); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	metrics.IncrCounterWithLabels([]string{"file", "update"}, 1, []metrics.Label{
+		{Name: "type", Value: file.Type},
+	})
+	logger.From(r.Context()).Info("file content updated", "file_id", file.ID, "user_id", file.UserID, "size", file.Size, "file_type", file.Type)
+
+	writeJSON(w, http.StatusOK, file)
+}
+
+func (a *API) ListRevisions(w http.ResponseWriter, r *http.Request) {
+	file := a.findFile(w, r, false)
+	if file == nil {
+		return
+	}
+
+	limit, ok := pageSize(w, r)
+	if !ok {
+		return
+	}
+
+	offset, ok := decodeCursor(w, r)
+	if !ok {
+		return
+	}
+
+	// fetch one extra row to learn whether another page exists
+	revisions, err := a.db.FindRevisionsByFileID(r.Context(), file.ID, db.WithLimit(limit+1), db.WithOffset(offset))
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	type response struct {
+		Revisions  []*snips.Revision `json:"revisions"`
+		NextCursor string            `json:"next_cursor,omitempty"`
+	}
+
+	resp := response{Revisions: revisions}
+	if uint64(len(revisions)) > limit {
+		resp.Revisions = revisions[:limit]
+		resp.NextCursor = encodeCursor(offset + limit)
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (a *API) GetRevision(w http.ResponseWriter, r *http.Request) {
+	file := a.findFile(w, r, false)
+	if file == nil {
+		return
+	}
+
+	sequence, err := strconv.ParseInt(r.PathValue("sequence"), 10, 64)
+	if err != nil || sequence < 1 {
+		http.Error(w, "sequence must be a positive integer", http.StatusBadRequest)
+		return
+	}
+
+	rev, err := a.db.FindRevisionByFileIDAndSequence(r.Context(), file.ID, sequence)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if rev == nil {
+		http.Error(w, "revision not found", http.StatusNotFound)
+		return
+	}
+
+	diff, err := rev.GetDiff()
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, struct {
+		*snips.Revision
+		Diff string `json:"diff"`
+	}{rev, string(diff)})
+}
+
+func (a *API) SignFile(w http.ResponseWriter, r *http.Request) {
+	file := a.findFile(w, r, true)
+	if file == nil {
+		return
+	}
+
+	if !file.Private {
+		http.Error(w, "only private files can be signed", http.StatusBadRequest)
+		return
+	}
+
+	var body struct {
+		TTLSeconds int64 `json:"ttl_seconds"`
+	}
+
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		http.Error(w, "invalid json body", http.StatusBadRequest)
+		return
+	}
+
+	if body.TTLSeconds < 1 {
+		http.Error(w, "ttl_seconds must be a positive integer", http.StatusBadRequest)
+		return
+	}
+
+	signedURL, expires := file.GetSignedURL(a.cfg, time.Duration(body.TTLSeconds)*time.Second)
+
+	metrics.IncrCounter([]string{"file", "sign"}, 1)
+	logger.From(r.Context()).Info("private file signed", "file_id", file.ID, "expires_at", expires)
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"url":        signedURL.String(),
+		"expires_at": expires.UTC(),
+	})
+}

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -1,0 +1,490 @@
+package web_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/robherley/snips.sh/internal/config"
+	"github.com/robherley/snips.sh/internal/db"
+	"github.com/robherley/snips.sh/internal/snips"
+	"github.com/robherley/snips.sh/internal/testutil"
+	"github.com/robherley/snips.sh/internal/web"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type APISuite struct {
+	suite.Suite
+
+	config *config.Config
+	assets web.Assets
+	mockDB *db.MockDB
+	server *httptest.Server
+
+	token  string
+	apiKey *snips.APIKey
+	userID string
+}
+
+func TestAPISuite(t *testing.T) {
+	suite.Run(t, new(APISuite))
+}
+
+func (suite *APISuite) SetupSuite() {
+	var err error
+	suite.config, err = config.Load()
+	suite.Require().NoError(err)
+
+	suite.assets = testutil.Assets(suite.T())
+}
+
+func (suite *APISuite) SetupTest() {
+	suite.mockDB = db.NewMockDB(suite.T())
+
+	service, err := web.New(suite.config, suite.mockDB, suite.assets)
+	suite.Require().NoError(err)
+
+	suite.server = httptest.NewServer(service.Handler)
+
+	token, hash, err := snips.NewAPIKeyToken()
+	suite.Require().NoError(err)
+
+	suite.token = token
+	suite.userID = "user123"
+	suite.apiKey = &snips.APIKey{
+		ID:        "key123",
+		TokenHash: hash,
+		UserID:    suite.userID,
+	}
+}
+
+func (suite *APISuite) TearDownTest() {
+	suite.server.Close()
+}
+
+// expectAuth wires the mock calls every authenticated request makes.
+func (suite *APISuite) expectAuth() {
+	suite.mockDB.EXPECT().FindAPIKeyByTokenHash(mock.Anything, snips.HashAPIKeyToken(suite.token)).Return(suite.apiKey, nil).Once()
+	suite.mockDB.EXPECT().TouchAPIKey(mock.Anything, suite.apiKey.ID).Return(nil).Once()
+}
+
+func (suite *APISuite) request(method, path string, body io.Reader, authed bool) *http.Response {
+	req, err := http.NewRequest(method, suite.server.URL+path, body)
+	suite.Require().NoError(err)
+
+	if authed {
+		req.Header.Set("Authorization", "Bearer "+suite.token)
+	}
+
+	res, err := suite.server.Client().Do(req)
+	suite.Require().NoError(err)
+
+	return res
+}
+
+func (suite *APISuite) decode(res *http.Response, v any) {
+	defer res.Body.Close()
+	suite.Require().NoError(json.NewDecoder(res.Body).Decode(v))
+}
+
+func (suite *APISuite) file(id string, private bool) *snips.File {
+	file := &snips.File{
+		ID:        id,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+		Private:   private,
+		Type:      "plaintext",
+		UserID:    suite.userID,
+	}
+	suite.Require().NoError(file.SetContent([]byte("hello world"), false))
+	file.Size = 11
+
+	return file
+}
+
+func (suite *APISuite) TestMetaMovedAndServed() {
+	client := suite.server.Client()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	res, err := client.Get(suite.server.URL + "/meta.json")
+	suite.Require().NoError(err)
+	defer res.Body.Close()
+	suite.Equal(http.StatusMovedPermanently, res.StatusCode)
+	suite.Equal("/api/v1/meta", res.Header.Get("Location"))
+
+	res, err = client.Get(suite.server.URL + "/api/v1/meta")
+	suite.Require().NoError(err)
+
+	meta := map[string]any{}
+	suite.decode(res, &meta)
+	suite.Contains(meta, "limits")
+	suite.Contains(meta["limits"], "api_keys_per_user")
+}
+
+func (suite *APISuite) TestUnauthorized() {
+	for _, header := range []string{"", "Bearer nope", "Bearer " + snips.APIKeyTokenPrefix + "unknown", "Basic foo"} {
+		req, err := http.NewRequest("GET", suite.server.URL+"/api/v1/user", nil)
+		suite.Require().NoError(err)
+		if header != "" {
+			req.Header.Set("Authorization", header)
+		}
+
+		if strings.HasPrefix(header, "Bearer "+snips.APIKeyTokenPrefix) {
+			suite.mockDB.EXPECT().FindAPIKeyByTokenHash(mock.Anything, mock.Anything).Return(nil, nil).Once()
+		}
+
+		res, err := suite.server.Client().Do(req)
+		suite.Require().NoError(err)
+		res.Body.Close()
+		suite.Equal(http.StatusUnauthorized, res.StatusCode, "header: %q", header)
+	}
+}
+
+func (suite *APISuite) TestGetUser() {
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindUser(mock.Anything, suite.userID).Return(&snips.User{ID: suite.userID, CreatedAt: time.Now().UTC()}, nil).Once()
+
+	res := suite.request("GET", "/api/v1/user", nil, true)
+	suite.Equal(http.StatusOK, res.StatusCode)
+
+	user := map[string]any{}
+	suite.decode(res, &user)
+	suite.Equal(suite.userID, user["id"])
+}
+
+func (suite *APISuite) TestListFiles_Paginated() {
+	files := []*snips.File{}
+	for _, id := range []string{"file3", "file2", "file1"} {
+		files = append(files, suite.file(id, false))
+	}
+
+	// page size 2 → the handler asks for 3 and returns a next_cursor
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFilesByUser(mock.Anything, suite.userID, mock.Anything, mock.Anything).Return(files, nil).Once()
+
+	res := suite.request("GET", "/api/v1/files?limit=2", nil, true)
+	suite.Equal(http.StatusOK, res.StatusCode)
+
+	page := struct {
+		Files      []map[string]any `json:"files"`
+		NextCursor string           `json:"next_cursor"`
+	}{}
+	suite.decode(res, &page)
+	suite.Len(page.Files, 2)
+	suite.Equal("file3", page.Files[0]["id"])
+	suite.NotEmpty(page.NextCursor)
+
+	// following the cursor resumes at the encoded offset
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFilesByUser(mock.Anything, suite.userID, mock.Anything, mock.Anything).Return(files[2:], nil).Once()
+
+	res = suite.request("GET", "/api/v1/files?limit=2&cursor="+page.NextCursor, nil, true)
+	suite.Equal(http.StatusOK, res.StatusCode)
+
+	page.NextCursor = ""
+	suite.decode(res, &page)
+	suite.Len(page.Files, 1)
+	suite.Equal("file1", page.Files[0]["id"])
+	suite.Empty(page.NextCursor)
+}
+
+func (suite *APISuite) TestListFiles_BadCursorAndLimit() {
+	suite.expectAuth()
+	res := suite.request("GET", "/api/v1/files?cursor=!!!", nil, true)
+	res.Body.Close()
+	suite.Equal(http.StatusBadRequest, res.StatusCode)
+
+	suite.expectAuth()
+	res = suite.request("GET", "/api/v1/files?limit=9999", nil, true)
+	res.Body.Close()
+	suite.Equal(http.StatusBadRequest, res.StatusCode)
+}
+
+func (suite *APISuite) TestListFiles_ByName() {
+	file := suite.file("file1", false)
+	file.Name = "notes"
+
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFileByName(mock.Anything, suite.userID, "notes").Return(file, nil).Once()
+
+	res := suite.request("GET", "/api/v1/files?name=notes", nil, true)
+	suite.Equal(http.StatusOK, res.StatusCode)
+
+	page := struct {
+		Files []map[string]any `json:"files"`
+	}{}
+	suite.decode(res, &page)
+	suite.Len(page.Files, 1)
+	suite.Equal("notes", page.Files[0]["name"])
+}
+
+func (suite *APISuite) TestCreateFile() {
+	suite.expectAuth()
+	suite.mockDB.EXPECT().CreateFile(mock.Anything, mock.Anything, suite.config.Limits.FilesPerUser).RunAndReturn(
+		func(_ context.Context, file *snips.File, _ uint64) error {
+			file.ID = "newfile"
+			return nil
+		}).Once()
+
+	res := suite.request("POST", "/api/v1/files?name=hello&private=true", strings.NewReader("hello world"), true)
+	suite.Equal(http.StatusCreated, res.StatusCode)
+
+	file := map[string]any{}
+	suite.decode(res, &file)
+	suite.Equal("newfile", file["id"])
+	suite.Equal("hello", file["name"])
+	suite.Equal(true, file["private"])
+}
+
+func (suite *APISuite) TestCreateFile_Errors() {
+	// empty body
+	suite.expectAuth()
+	res := suite.request("POST", "/api/v1/files", strings.NewReader(""), true)
+	res.Body.Close()
+	suite.Equal(http.StatusBadRequest, res.StatusCode)
+
+	// over the size limit
+	suite.expectAuth()
+	res = suite.request("POST", "/api/v1/files", strings.NewReader(strings.Repeat("a", int(suite.config.Limits.FileSize)+1)), true)
+	res.Body.Close()
+	suite.Equal(http.StatusRequestEntityTooLarge, res.StatusCode)
+
+	// invalid name
+	suite.expectAuth()
+	res = suite.request("POST", "/api/v1/files?name=no/slashes", strings.NewReader("hi"), true)
+	res.Body.Close()
+	suite.Equal(http.StatusBadRequest, res.StatusCode)
+
+	// name taken
+	suite.expectAuth()
+	suite.mockDB.EXPECT().CreateFile(mock.Anything, mock.Anything, mock.Anything).Return(db.ErrNameTaken).Once()
+	res = suite.request("POST", "/api/v1/files?name=taken", strings.NewReader("hi"), true)
+	res.Body.Close()
+	suite.Equal(http.StatusConflict, res.StatusCode)
+
+	// file limit
+	suite.expectAuth()
+	suite.mockDB.EXPECT().CreateFile(mock.Anything, mock.Anything, mock.Anything).Return(db.ErrFileLimit).Once()
+	res = suite.request("POST", "/api/v1/files", strings.NewReader("hi"), true)
+	res.Body.Close()
+	suite.Equal(http.StatusUnprocessableEntity, res.StatusCode)
+}
+
+func (suite *APISuite) TestGetFile_Visibility() {
+	// own private file is visible
+	private := suite.file("mine", true)
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "mine").Return(private, nil).Once()
+	res := suite.request("GET", "/api/v1/files/mine", nil, true)
+	res.Body.Close()
+	suite.Equal(http.StatusOK, res.StatusCode)
+
+	// someone else's public file is visible
+	public := suite.file("theirs-public", false)
+	public.UserID = "someone-else"
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "theirs-public").Return(public, nil).Once()
+	res = suite.request("GET", "/api/v1/files/theirs-public", nil, true)
+	res.Body.Close()
+	suite.Equal(http.StatusOK, res.StatusCode)
+
+	// someone else's private file is a 404
+	hidden := suite.file("theirs-private", true)
+	hidden.UserID = "someone-else"
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "theirs-private").Return(hidden, nil).Once()
+	res = suite.request("GET", "/api/v1/files/theirs-private", nil, true)
+	res.Body.Close()
+	suite.Equal(http.StatusNotFound, res.StatusCode)
+
+	// nonexistent file is a 404
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "nope").Return(nil, nil).Once()
+	res = suite.request("GET", "/api/v1/files/nope", nil, true)
+	res.Body.Close()
+	suite.Equal(http.StatusNotFound, res.StatusCode)
+}
+
+func (suite *APISuite) TestUpdateFile() {
+	file := suite.file("file1", false)
+
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "file1").Return(file, nil).Once()
+	suite.mockDB.EXPECT().UpdateFile(mock.Anything, mock.Anything).Return(nil).Once()
+
+	res := suite.request("PATCH", "/api/v1/files/file1", strings.NewReader(`{"name":"renamed","private":true}`), true)
+	suite.Equal(http.StatusOK, res.StatusCode)
+
+	updated := map[string]any{}
+	suite.decode(res, &updated)
+	suite.Equal("renamed", updated["name"])
+	suite.Equal(true, updated["private"])
+}
+
+func (suite *APISuite) TestUpdateFile_MutationsAreOwnerOnly() {
+	public := suite.file("theirs", false)
+	public.UserID = "someone-else"
+
+	// even a public file 404s for non-owners on mutation
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "theirs").Return(public, nil).Once()
+	res := suite.request("PATCH", "/api/v1/files/theirs", strings.NewReader(`{"private":true}`), true)
+	res.Body.Close()
+	suite.Equal(http.StatusNotFound, res.StatusCode)
+}
+
+func (suite *APISuite) TestUpdateFile_EmptyPatch() {
+	file := suite.file("file1", false)
+
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "file1").Return(file, nil).Once()
+
+	res := suite.request("PATCH", "/api/v1/files/file1", strings.NewReader(`{}`), true)
+	res.Body.Close()
+	suite.Equal(http.StatusBadRequest, res.StatusCode)
+}
+
+func (suite *APISuite) TestDeleteFile() {
+	file := suite.file("file1", false)
+
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "file1").Return(file, nil).Once()
+	suite.mockDB.EXPECT().DeleteFile(mock.Anything, "file1").Return(nil).Once()
+
+	res := suite.request("DELETE", "/api/v1/files/file1", nil, true)
+	res.Body.Close()
+	suite.Equal(http.StatusNoContent, res.StatusCode)
+}
+
+func (suite *APISuite) TestGetFileContent() {
+	file := suite.file("file1", false)
+
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "file1").Return(file, nil).Once()
+
+	res := suite.request("GET", "/api/v1/files/file1/content", nil, true)
+	suite.Equal(http.StatusOK, res.StatusCode)
+	suite.Contains(res.Header.Get("Content-Type"), "text/plain")
+
+	body, err := io.ReadAll(res.Body)
+	res.Body.Close()
+	suite.Require().NoError(err)
+	suite.Equal("hello world", string(body))
+}
+
+func (suite *APISuite) TestUpdateFileContent() {
+	file := suite.file("file1", false)
+
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "file1").Return(file, nil).Once()
+	suite.mockDB.EXPECT().CountRevisionsByFileID(mock.Anything, "file1").Return(0, nil).Once()
+	suite.mockDB.EXPECT().CreateRevision(mock.Anything, mock.Anything, suite.config.Limits.RevisionsPerFile).Return(nil).Once()
+	suite.mockDB.EXPECT().UpdateFile(mock.Anything, mock.Anything).Return(nil).Once()
+
+	res := suite.request("PUT", "/api/v1/files/file1/content", strings.NewReader("hello new world"), true)
+	suite.Equal(http.StatusOK, res.StatusCode)
+
+	updated := map[string]any{}
+	suite.decode(res, &updated)
+	suite.Equal(float64(15), updated["size"])
+}
+
+func (suite *APISuite) TestListRevisions() {
+	file := suite.file("file1", false)
+	revisions := []*snips.Revision{
+		{ID: "rev3", Sequence: 3, FileID: "file1", CreatedAt: time.Now().UTC()},
+		{ID: "rev2", Sequence: 2, FileID: "file1", CreatedAt: time.Now().UTC()},
+	}
+
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "file1").Return(file, nil).Once()
+	suite.mockDB.EXPECT().FindRevisionsByFileID(mock.Anything, "file1", mock.Anything, mock.Anything).Return(revisions, nil).Once()
+
+	res := suite.request("GET", "/api/v1/files/file1/revisions?limit=1", nil, true)
+	suite.Equal(http.StatusOK, res.StatusCode)
+
+	page := struct {
+		Revisions  []map[string]any `json:"revisions"`
+		NextCursor string           `json:"next_cursor"`
+	}{}
+	suite.decode(res, &page)
+	suite.Len(page.Revisions, 1)
+	suite.Equal(float64(3), page.Revisions[0]["sequence"])
+	suite.NotEmpty(page.NextCursor)
+}
+
+func (suite *APISuite) TestGetRevision() {
+	file := suite.file("file1", false)
+	rev := &snips.Revision{ID: "rev1", Sequence: 1, FileID: "file1", CreatedAt: time.Now().UTC()}
+	suite.Require().NoError(rev.SetDiff([]byte("+hello"), false))
+
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "file1").Return(file, nil).Once()
+	suite.mockDB.EXPECT().FindRevisionByFileIDAndSequence(mock.Anything, "file1", int64(1)).Return(rev, nil).Once()
+
+	res := suite.request("GET", "/api/v1/files/file1/revisions/1", nil, true)
+	suite.Equal(http.StatusOK, res.StatusCode)
+
+	revision := map[string]any{}
+	suite.decode(res, &revision)
+	suite.Equal("+hello", revision["diff"])
+}
+
+func (suite *APISuite) TestSignFile() {
+	private := suite.file("file1", true)
+
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "file1").Return(private, nil).Once()
+
+	res := suite.request("POST", "/api/v1/files/file1/sign", strings.NewReader(`{"ttl_seconds":3600}`), true)
+	suite.Equal(http.StatusCreated, res.StatusCode)
+
+	signed := map[string]any{}
+	suite.decode(res, &signed)
+	suite.Contains(signed["url"], "/f/file1")
+	suite.Contains(signed["url"], "sig=")
+	suite.NotEmpty(signed["expires_at"])
+}
+
+func (suite *APISuite) TestSignFile_PublicRejected() {
+	public := suite.file("file1", false)
+
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "file1").Return(public, nil).Once()
+
+	res := suite.request("POST", "/api/v1/files/file1/sign", strings.NewReader(`{"ttl_seconds":3600}`), true)
+	res.Body.Close()
+	suite.Equal(http.StatusBadRequest, res.StatusCode)
+}
+
+func (suite *APISuite) TestOpenAPISpec() {
+	for path, contentType := range map[string]string{
+		"/openapi.yaml": "text/plain; charset=utf-8",
+		"/openapi.yml":  "text/plain; charset=utf-8",
+		"/openapi.json": "application/json",
+	} {
+		res, err := suite.server.Client().Get(suite.server.URL + path)
+		suite.Require().NoError(err)
+		suite.Equal(http.StatusOK, res.StatusCode, path)
+		suite.Equal(contentType, res.Header.Get("Content-Type"), path)
+
+		body, err := io.ReadAll(res.Body)
+		res.Body.Close()
+		suite.Require().NoError(err)
+		suite.Contains(string(body), "openapi", path)
+
+		if contentType == "application/json" {
+			doc := map[string]any{}
+			suite.Require().NoError(json.Unmarshal(body, &doc), path)
+			suite.Contains(doc, "paths")
+		}
+	}
+}

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -465,6 +465,17 @@ func (suite *APISuite) TestSignFile_PublicRejected() {
 	suite.Equal(http.StatusBadRequest, res.StatusCode)
 }
 
+func (suite *APISuite) TestSignFile_TTLOverflowRejected() {
+	private := suite.file("file1", true)
+
+	suite.expectAuth()
+	suite.mockDB.EXPECT().FindFile(mock.Anything, "file1").Return(private, nil).Once()
+
+	res := suite.request("POST", "/api/v1/files/file1/sign", strings.NewReader(`{"ttl_seconds":9223372037}`), true)
+	defer res.Body.Close()
+	suite.Equal(http.StatusBadRequest, res.StatusCode)
+}
+
 func (suite *APISuite) TestOpenAPISpec() {
 	for path, contentType := range map[string]string{
 		"/openapi.yaml": "text/plain; charset=utf-8",

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"html/template"
 	"image/png"
@@ -43,41 +42,6 @@ func ProfileHandler(w http.ResponseWriter, r *http.Request) {
 		// Available profiles can be found in [runtime/pprof.Profile].
 		// https://pkg.go.dev/runtime/pprof#Profile
 		pprof.Handler(profiler).ServeHTTP(w, r)
-	}
-}
-
-func MetaHandler(cfg *config.Config) http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
-		metadata := map[string]interface{}{
-			"limits": map[string]interface{}{
-				"file_size": map[string]interface{}{
-					"bytes": cfg.Limits.FileSize,
-					"human": humanize.Bytes(cfg.Limits.FileSize),
-				},
-				"files_per_user":     cfg.Limits.FilesPerUser,
-				"revisions_per_file": cfg.Limits.RevisionsPerFile,
-				"session_duration": map[string]interface{}{
-					"seconds": cfg.Limits.SessionDuration.Seconds(),
-					"human":   cfg.Limits.SessionDuration.String(),
-				},
-			},
-			"endpoints": map[string]interface{}{
-				"http": cfg.HTTP.External.String(),
-				"ssh":  cfg.SSH.External.String(),
-			},
-			"commit_sha":      config.BuildCommit(),
-			"guesser_enabled": cfg.EnableGuesser,
-		}
-
-		metabites, err := json.MarshalIndent(metadata, "", "  ")
-		if err != nil {
-			http.Error(w, "internal error", http.StatusInternalServerError)
-			return
-		}
-
-		_, _ = w.Write(metabites)
 	}
 }
 

--- a/internal/web/openapi.yaml
+++ b/internal/web/openapi.yaml
@@ -1,0 +1,588 @@
+openapi: 3.1.0
+info:
+  title: snips.sh API
+  description: |
+    REST API for snips.sh file operations.
+
+    Authentication uses API keys, presented as a bearer token:
+    `Authorization: Bearer snips_<token>`.
+
+    API keys are minted with your SSH key, never via this API:
+      - SSH: `ssh snips.sh api-key create -name my-key` (also `api-key ls`, `api-key rm <name>`)
+      - TUI: `ssh snips.sh` → `ctrl+p` → "api keys"
+
+    Each user may hold at most 16 active API keys. Tokens are shown once at
+    creation and stored server-side only as a SHA-256 hash.
+  version: 1.0.0
+servers:
+  - url: /api/v1
+
+security:
+  - apiKey: []
+
+paths:
+  /meta:
+    get:
+      operationId: getMeta
+      summary: Instance metadata
+      description: |
+        Public instance metadata (limits, endpoints, build info).
+        The legacy `/meta.json` endpoint now responds with a 301 redirect here.
+      security: []
+      responses:
+        "200":
+          description: Instance metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Meta"
+
+  /user:
+    get:
+      operationId: getUser
+      summary: Current user
+      description: Returns the user that owns the presented API key.
+      responses:
+        "200":
+          description: The authenticated user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /files:
+    get:
+      operationId: listFiles
+      summary: List files
+      description: |
+        Lists files owned by the authenticated user (metadata only, no
+        content), newest first. Paginated by opaque cursor:
+        when more files exist, the response carries `next_cursor` — pass it
+        back via `cursor` to fetch the next page.
+      parameters:
+        - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/cursor"
+        - name: name
+          in: query
+          description: |
+            Filter to the single file with this name (names are unique per
+            user, case-insensitive). Pagination parameters are ignored.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: One page of the user's files
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [files]
+                properties:
+                  files:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/File"
+                  next_cursor:
+                    $ref: "#/components/schemas/NextCursor"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      operationId: createFile
+      summary: Create a file
+      description: Uploads the raw request body as a new file.
+      parameters:
+        - name: name
+          in: query
+          description: Human-readable name, unique per user.
+          schema:
+            type: string
+        - name: private
+          in: query
+          description: Only accessible by the owner or via signed URLs.
+          schema:
+            type: boolean
+            default: false
+        - name: ext
+          in: query
+          description: File extension hint (e.g. `go`, `md`). Detected automatically when omitted.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          "*/*":
+            schema:
+              type: string
+              format: binary
+      responses:
+        "201":
+          description: File created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/File"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          description: A file with this name already exists.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestID"
+          content:
+            text/plain:
+              schema:
+                type: string
+        "413":
+          description: Content exceeds the per-file size limit.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestID"
+          content:
+            text/plain:
+              schema:
+                type: string
+        "422":
+          description: The per-user file count limit has been reached.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestID"
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /files/{id}:
+    parameters:
+      - $ref: "#/components/parameters/fileID"
+    get:
+      operationId: getFile
+      summary: Get file metadata
+      description: |
+        Returns file metadata. Files owned by other users are visible only if
+        public; otherwise 404.
+      responses:
+        "200":
+          description: File metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/File"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      operationId: updateFile
+      summary: Update file metadata
+      description: |
+        Updates name, visibility, and/or type. Owner only.
+        Set `"name": ""` to remove a name.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              minProperties: 1
+              properties:
+                name:
+                  type: string
+                  description: New name (unique per user); empty string removes the name.
+                private:
+                  type: boolean
+                type:
+                  type: string
+                  description: File extension / language (e.g. `go`, `md`).
+      responses:
+        "200":
+          description: Updated file metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/File"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: A file with this name already exists.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestID"
+          content:
+            text/plain:
+              schema:
+                type: string
+    delete:
+      operationId: deleteFile
+      summary: Delete a file
+      description: Permanently deletes a file and its revisions. Owner only.
+      responses:
+        "204":
+          description: File deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /files/{id}/content:
+    parameters:
+      - $ref: "#/components/parameters/fileID"
+    get:
+      operationId: getFileContent
+      summary: Download file content
+      description: |
+        Returns the raw, decompressed file content. Files owned by other users
+        are downloadable only if public.
+      responses:
+        "200":
+          description: Raw file content
+          content:
+            text/plain:
+              schema:
+                type: string
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    put:
+      operationId: updateFileContent
+      summary: Replace file content
+      description: |
+        Replaces the file's content with the raw request body and records a
+        revision diff. Owner only.
+      parameters:
+        - name: ext
+          in: query
+          description: File extension hint; re-detected when omitted.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          "*/*":
+            schema:
+              type: string
+              format: binary
+      responses:
+        "200":
+          description: Updated file metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/File"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "413":
+          description: Content exceeds the per-file size limit.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestID"
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /files/{id}/revisions:
+    parameters:
+      - $ref: "#/components/parameters/fileID"
+    get:
+      operationId: listRevisions
+      summary: List file revisions
+      description: |
+        Lists revision metadata (no diffs), newest first. Same visibility
+        rules as the file. Paginated by opaque cursor, like `listFiles`.
+      parameters:
+        - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/cursor"
+      responses:
+        "200":
+          description: One page of the file's revisions
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [revisions]
+                properties:
+                  revisions:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Revision"
+                  next_cursor:
+                    $ref: "#/components/schemas/NextCursor"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /files/{id}/revisions/{sequence}:
+    parameters:
+      - $ref: "#/components/parameters/fileID"
+      - name: sequence
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+    get:
+      operationId: getRevision
+      summary: Get a revision
+      description: Returns revision metadata including its unified diff.
+      responses:
+        "200":
+          description: The revision
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Revision"
+                  - type: object
+                    required: [diff]
+                    properties:
+                      diff:
+                        type: string
+                        description: Unified diff against the previous revision.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /files/{id}/sign:
+    parameters:
+      - $ref: "#/components/parameters/fileID"
+    post:
+      operationId: signFile
+      summary: Create a signed URL
+      description: Creates a time-limited signed URL for a **private** file. Owner only.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [ttl_seconds]
+              properties:
+                ttl_seconds:
+                  type: integer
+                  format: int64
+                  minimum: 1
+                  description: Lifetime of the signed URL in seconds.
+      responses:
+        "201":
+          description: Signed URL created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [url, expires_at]
+                properties:
+                  url:
+                    type: string
+                    format: uri
+                  expires_at:
+                    type: string
+                    format: date-time
+        "400":
+          description: Invalid TTL, or the file is not private.
+          headers:
+            X-Request-ID:
+              $ref: "#/components/headers/XRequestID"
+          content:
+            text/plain:
+              schema:
+                type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+components:
+  securitySchemes:
+    apiKey:
+      type: http
+      scheme: bearer
+      bearerFormat: snips_<token>
+      description: "API key minted via SSH or the TUI, e.g. `Authorization: Bearer snips_abc123...`"
+
+  parameters:
+    limit:
+      name: limit
+      in: query
+      description: Maximum items per page.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 50
+    cursor:
+      name: cursor
+      in: query
+      description: Opaque pagination cursor from a previous response's `next_cursor`.
+      schema:
+        type: string
+    fileID:
+      name: id
+      in: path
+      required: true
+      description: File ID (e.g. from `listFiles` or the file's URL).
+      schema:
+        type: string
+
+  responses:
+    Unauthorized:
+      description: Missing, malformed, or unknown API key.
+      headers:
+        X-Request-ID:
+          $ref: "#/components/headers/XRequestID"
+      content:
+        text/plain:
+          schema:
+            type: string
+    NotFound:
+      description: File does not exist or is not accessible.
+      headers:
+        X-Request-ID:
+          $ref: "#/components/headers/XRequestID"
+      content:
+        text/plain:
+          schema:
+            type: string
+    BadRequest:
+      description: Invalid request parameters or body.
+      headers:
+        X-Request-ID:
+          $ref: "#/components/headers/XRequestID"
+      content:
+        text/plain:
+          schema:
+            type: string
+
+  headers:
+    XRequestID:
+      description: Unique ID of the request; reference it when reporting issues.
+      schema:
+        type: string
+
+  schemas:
+    NextCursor:
+      type: string
+      description: Opaque cursor for the next page; absent on the last page.
+
+    User:
+      type: object
+      required: [id, created_at, updated_at]
+      properties:
+        id:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    File:
+      type: object
+      required: [id, size, private, type, created_at, updated_at]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+          description: Optional per-user unique name; omitted when unnamed.
+        size:
+          type: integer
+          format: int64
+          description: Content size in bytes.
+        private:
+          type: boolean
+        type:
+          type: string
+          description: Detected type (`binary`, `markdown`, or a language/extension).
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    Revision:
+      type: object
+      required: [id, sequence, size, type, created_at]
+      properties:
+        id:
+          type: string
+        sequence:
+          type: integer
+          format: int64
+        size:
+          type: integer
+          format: int64
+          description: Size of the diff in bytes.
+        type:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+
+    Meta:
+      type: object
+      required: [limits, endpoints, commit_sha, guesser_enabled]
+      properties:
+        limits:
+          type: object
+          properties:
+            file_size:
+              type: object
+              properties:
+                bytes:
+                  type: integer
+                  format: int64
+                human:
+                  type: string
+            files_per_user:
+              type: integer
+              format: int64
+            revisions_per_file:
+              type: integer
+              format: int64
+            api_keys_per_user:
+              type: integer
+              format: int64
+            session_duration:
+              type: object
+              properties:
+                seconds:
+                  type: number
+                human:
+                  type: string
+        endpoints:
+          type: object
+          properties:
+            http:
+              type: string
+              format: uri
+            ssh:
+              type: string
+        commit_sha:
+          type: string
+        guesser_enabled:
+          type: boolean

--- a/internal/web/openapi.yaml
+++ b/internal/web/openapi.yaml
@@ -384,6 +384,7 @@ paths:
                   type: integer
                   format: int64
                   minimum: 1
+                  maximum: 9223372036
                   description: Lifetime of the signed URL in seconds.
       responses:
         "201":
@@ -536,7 +537,7 @@ components:
         size:
           type: integer
           format: int64
-          description: Size of the diff in bytes.
+          description: Content size after this revision, in bytes.
         type:
           type: string
         created_at:

--- a/internal/web/service.go
+++ b/internal/web/service.go
@@ -28,7 +28,8 @@ func New(cfg *config.Config, database db.DB, assets Assets) (*Service, error) {
 	mux.HandleFunc("GET /f/{fileID}/n/{name}/rev/{revisionID}", RevisionDiffHandler(cfg, database, assets))
 	mux.HandleFunc("GET /f/{fileID}/n/{name}/og.png", OGImageHandler(cfg, database, assets))
 	mux.HandleFunc("GET /assets/{asset...}", assets.Serve)
-	mux.HandleFunc("GET /meta.json", MetaHandler(cfg))
+
+	NewAPI(cfg, database).Register(mux)
 
 	if cfg.Debug {
 		mux.HandleFunc("/_debug/pprof/{profile}", ProfileHandler)


### PR DESCRIPTION
For #276 

This builds on the API key changes in from #293, where they can now be used against the REST API.

The API reflects operations achievable via the tui/ssh, but mostly centered around files:

```
GET    /api/v1/meta
GET    /api/v1/user
GET    /api/v1/files
POST   /api/v1/files
GET    /api/v1/files/{id}
PATCH  /api/v1/files/{id}
DELETE /api/v1/files/{id}
GET    /api/v1/files/{id}/content
PUT    /api/v1/files/{id}/content
GET    /api/v1/files/{id}/revisions
GET    /api/v1/files/{id}/revisions/{sequence}
POST   /api/v1/files/{id}/sign
```

The full openapi spec is hosted at `/openapi.{json,yaml,yml}`. There's also pagination on the list-style endpoints.
