### PR TITLE
feat(auth): add api keys

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,7 @@ type Config struct {
 		FilesPerUser     uint64        `default:"100" desc:"maximum number of files per user"`
 		SessionDuration  time.Duration `default:"15m" desc:"maximum ssh session duration"`
 		RevisionsPerFile uint64        `default:"64" desc:"maximum number of revisions per file"`
+		APIKeysPerUser   uint64        `default:"16" desc:"maximum number of api keys per user"`
 	}
 
 	DB struct {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -43,4 +43,14 @@ type DB interface {
 	FindRevisionByFileIDAndSequence(ctx context.Context, fileID string, sequence int64) (*snips.Revision, error)
 	// CountRevisionsByFileID returns the number of revisions for a file.
 	CountRevisionsByFileID(ctx context.Context, fileID string) (int64, error)
+	// CreateAPIKey creates a new API key. If a user has maxKeys or more keys, ErrAPIKeyLimit is returned.
+	CreateAPIKey(ctx context.Context, key *snips.APIKey, maxKeys uint64) error
+	// FindAPIKeyByTokenHash returns an API key by its token hash.
+	FindAPIKeyByTokenHash(ctx context.Context, tokenHash string) (*snips.APIKey, error)
+	// FindAPIKeysByUser returns all API keys for a user, newest first.
+	FindAPIKeysByUser(ctx context.Context, userID string) ([]*snips.APIKey, error)
+	// DeleteAPIKey deletes a user's API key by ID, reporting whether a key was deleted.
+	DeleteAPIKey(ctx context.Context, id, userID string) (bool, error)
+	// TouchAPIKey updates an API key's last_used_at timestamp.
+	TouchAPIKey(ctx context.Context, id string) error
 }

--- a/internal/db/db_mock.go
+++ b/internal/db/db_mock.go
@@ -170,6 +170,69 @@ func (_c *MockDB_CountRevisionsByFileID_Call) RunAndReturn(run func(ctx context.
 	return _c
 }
 
+// CreateAPIKey provides a mock function for the type MockDB
+func (_mock *MockDB) CreateAPIKey(ctx context.Context, key *snips.APIKey, maxKeys uint64) error {
+	ret := _mock.Called(ctx, key, maxKeys)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateAPIKey")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *snips.APIKey, uint64) error); ok {
+		r0 = returnFunc(ctx, key, maxKeys)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockDB_CreateAPIKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateAPIKey'
+type MockDB_CreateAPIKey_Call struct {
+	*mock.Call
+}
+
+// CreateAPIKey is a helper method to define mock.On call
+//   - ctx context.Context
+//   - key *snips.APIKey
+//   - maxKeys uint64
+func (_e *MockDB_Expecter) CreateAPIKey(ctx any, key any, maxKeys any) *MockDB_CreateAPIKey_Call {
+	return &MockDB_CreateAPIKey_Call{Call: _e.mock.On("CreateAPIKey", ctx, key, maxKeys)}
+}
+
+func (_c *MockDB_CreateAPIKey_Call) Run(run func(ctx context.Context, key *snips.APIKey, maxKeys uint64)) *MockDB_CreateAPIKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *snips.APIKey
+		if args[1] != nil {
+			arg1 = args[1].(*snips.APIKey)
+		}
+		var arg2 uint64
+		if args[2] != nil {
+			arg2 = args[2].(uint64)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDB_CreateAPIKey_Call) Return(err error) *MockDB_CreateAPIKey_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockDB_CreateAPIKey_Call) RunAndReturn(run func(ctx context.Context, key *snips.APIKey, maxKeys uint64) error) *MockDB_CreateAPIKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateFile provides a mock function for the type MockDB
 func (_mock *MockDB) CreateFile(ctx context.Context, file *snips.File, maxFiles uint64) error {
 	ret := _mock.Called(ctx, file, maxFiles)
@@ -364,6 +427,78 @@ func (_c *MockDB_CreateUserWithPublicKey_Call) RunAndReturn(run func(ctx context
 	return _c
 }
 
+// DeleteAPIKey provides a mock function for the type MockDB
+func (_mock *MockDB) DeleteAPIKey(ctx context.Context, id string, userID string) (bool, error) {
+	ret := _mock.Called(ctx, id, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAPIKey")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) (bool, error)); ok {
+		return returnFunc(ctx, id, userID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) bool); ok {
+		r0 = returnFunc(ctx, id, userID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = returnFunc(ctx, id, userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDB_DeleteAPIKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAPIKey'
+type MockDB_DeleteAPIKey_Call struct {
+	*mock.Call
+}
+
+// DeleteAPIKey is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+//   - userID string
+func (_e *MockDB_Expecter) DeleteAPIKey(ctx any, id any, userID any) *MockDB_DeleteAPIKey_Call {
+	return &MockDB_DeleteAPIKey_Call{Call: _e.mock.On("DeleteAPIKey", ctx, id, userID)}
+}
+
+func (_c *MockDB_DeleteAPIKey_Call) Run(run func(ctx context.Context, id string, userID string)) *MockDB_DeleteAPIKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDB_DeleteAPIKey_Call) Return(b bool, err error) *MockDB_DeleteAPIKey_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockDB_DeleteAPIKey_Call) RunAndReturn(run func(ctx context.Context, id string, userID string) (bool, error)) *MockDB_DeleteAPIKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteFile provides a mock function for the type MockDB
 func (_mock *MockDB) DeleteFile(ctx context.Context, id string) error {
 	ret := _mock.Called(ctx, id)
@@ -483,6 +618,142 @@ func (_c *MockDB_DeleteFilesByUser_Call) Return(n int64, err error) *MockDB_Dele
 }
 
 func (_c *MockDB_DeleteFilesByUser_Call) RunAndReturn(run func(ctx context.Context, userID string) (int64, error)) *MockDB_DeleteFilesByUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FindAPIKeyByTokenHash provides a mock function for the type MockDB
+func (_mock *MockDB) FindAPIKeyByTokenHash(ctx context.Context, tokenHash string) (*snips.APIKey, error) {
+	ret := _mock.Called(ctx, tokenHash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindAPIKeyByTokenHash")
+	}
+
+	var r0 *snips.APIKey
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (*snips.APIKey, error)); ok {
+		return returnFunc(ctx, tokenHash)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) *snips.APIKey); ok {
+		r0 = returnFunc(ctx, tokenHash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*snips.APIKey)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, tokenHash)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDB_FindAPIKeyByTokenHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindAPIKeyByTokenHash'
+type MockDB_FindAPIKeyByTokenHash_Call struct {
+	*mock.Call
+}
+
+// FindAPIKeyByTokenHash is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tokenHash string
+func (_e *MockDB_Expecter) FindAPIKeyByTokenHash(ctx any, tokenHash any) *MockDB_FindAPIKeyByTokenHash_Call {
+	return &MockDB_FindAPIKeyByTokenHash_Call{Call: _e.mock.On("FindAPIKeyByTokenHash", ctx, tokenHash)}
+}
+
+func (_c *MockDB_FindAPIKeyByTokenHash_Call) Run(run func(ctx context.Context, tokenHash string)) *MockDB_FindAPIKeyByTokenHash_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDB_FindAPIKeyByTokenHash_Call) Return(aPIKey *snips.APIKey, err error) *MockDB_FindAPIKeyByTokenHash_Call {
+	_c.Call.Return(aPIKey, err)
+	return _c
+}
+
+func (_c *MockDB_FindAPIKeyByTokenHash_Call) RunAndReturn(run func(ctx context.Context, tokenHash string) (*snips.APIKey, error)) *MockDB_FindAPIKeyByTokenHash_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// FindAPIKeysByUser provides a mock function for the type MockDB
+func (_mock *MockDB) FindAPIKeysByUser(ctx context.Context, userID string) ([]*snips.APIKey, error) {
+	ret := _mock.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindAPIKeysByUser")
+	}
+
+	var r0 []*snips.APIKey
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]*snips.APIKey, error)); ok {
+		return returnFunc(ctx, userID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []*snips.APIKey); ok {
+		r0 = returnFunc(ctx, userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*snips.APIKey)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDB_FindAPIKeysByUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindAPIKeysByUser'
+type MockDB_FindAPIKeysByUser_Call struct {
+	*mock.Call
+}
+
+// FindAPIKeysByUser is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+func (_e *MockDB_Expecter) FindAPIKeysByUser(ctx any, userID any) *MockDB_FindAPIKeysByUser_Call {
+	return &MockDB_FindAPIKeysByUser_Call{Call: _e.mock.On("FindAPIKeysByUser", ctx, userID)}
+}
+
+func (_c *MockDB_FindAPIKeysByUser_Call) Run(run func(ctx context.Context, userID string)) *MockDB_FindAPIKeysByUser_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDB_FindAPIKeysByUser_Call) Return(aPIKeys []*snips.APIKey, err error) *MockDB_FindAPIKeysByUser_Call {
+	_c.Call.Return(aPIKeys, err)
+	return _c
+}
+
+func (_c *MockDB_FindAPIKeysByUser_Call) RunAndReturn(run func(ctx context.Context, userID string) ([]*snips.APIKey, error)) *MockDB_FindAPIKeysByUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1052,6 +1323,63 @@ func (_c *MockDB_Migrate_Call) Return(err error) *MockDB_Migrate_Call {
 }
 
 func (_c *MockDB_Migrate_Call) RunAndReturn(run func(ctx context.Context) error) *MockDB_Migrate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// TouchAPIKey provides a mock function for the type MockDB
+func (_mock *MockDB) TouchAPIKey(ctx context.Context, id string) error {
+	ret := _mock.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TouchAPIKey")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockDB_TouchAPIKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TouchAPIKey'
+type MockDB_TouchAPIKey_Call struct {
+	*mock.Call
+}
+
+// TouchAPIKey is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id string
+func (_e *MockDB_Expecter) TouchAPIKey(ctx any, id any) *MockDB_TouchAPIKey_Call {
+	return &MockDB_TouchAPIKey_Call{Call: _e.mock.On("TouchAPIKey", ctx, id)}
+}
+
+func (_c *MockDB_TouchAPIKey_Call) Run(run func(ctx context.Context, id string)) *MockDB_TouchAPIKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDB_TouchAPIKey_Call) Return(err error) *MockDB_TouchAPIKey_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockDB_TouchAPIKey_Call) RunAndReturn(run func(ctx context.Context, id string) error) *MockDB_TouchAPIKey_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/db/db_sqlite.go
+++ b/internal/db/db_sqlite.go
@@ -656,27 +656,11 @@ func (s *Sqlite) FindUser(ctx context.Context, id string) (*snips.User, error) {
 }
 
 func (s *Sqlite) CreateAPIKey(ctx context.Context, key *snips.APIKey, maxKeys uint64) error {
-	const countQuery = `
-		SELECT COUNT(*)
-		FROM api_keys
-		WHERE user_id = ?
-	`
+	keyID := id.New()
+	createdAt := time.Now().UTC()
+	updatedAt := time.Now().UTC()
 
-	var count uint64
-	row := s.QueryRowContext(ctx, countQuery, key.UserID)
-	if err := row.Scan(&count); err != nil {
-		return err
-	}
-
-	if maxKeys > 0 && count >= maxKeys {
-		return ErrAPIKeyLimit
-	}
-
-	key.ID = id.New()
-	key.CreatedAt = time.Now().UTC()
-	key.UpdatedAt = time.Now().UTC()
-
-	const insertQuery = `
+	insertQuery := `
 		INSERT INTO api_keys (
 			id,
 			created_at,
@@ -686,20 +670,42 @@ func (s *Sqlite) CreateAPIKey(ctx context.Context, key *snips.APIKey, maxKeys ui
 			user_id,
 			last_used_at,
 			expires_at
-		) VALUES (?, ?, ?, ?, ?, ?, NULL, ?)
+		) SELECT ?, ?, ?, ?, ?, ?, NULL, ?
 	`
 
-	_, err := s.ExecContext(ctx, insertQuery,
-		key.ID,
-		key.CreatedAt,
-		key.UpdatedAt,
+	args := []any{
+		keyID,
+		createdAt,
+		updatedAt,
 		nullableName(key.Name),
 		key.TokenHash,
 		key.UserID,
 		key.ExpiresAt,
-	)
+	}
+	if maxKeys > 0 {
+		insertQuery += `
+			WHERE (SELECT COUNT(*) FROM api_keys WHERE user_id = ?) < ?
+		`
+		args = append(args, key.UserID, maxKeys)
+	}
 
-	return err
+	result, err := s.ExecContext(ctx, insertQuery, args...)
+	if err != nil {
+		return err
+	}
+
+	created, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if created == 0 {
+		return ErrAPIKeyLimit
+	}
+
+	key.ID = keyID
+	key.CreatedAt = createdAt
+	key.UpdatedAt = updatedAt
+	return nil
 }
 
 func (s *Sqlite) FindAPIKeyByTokenHash(ctx context.Context, tokenHash string) (*snips.APIKey, error) {

--- a/internal/db/db_sqlite.go
+++ b/internal/db/db_sqlite.go
@@ -655,6 +655,175 @@ func (s *Sqlite) FindUser(ctx context.Context, id string) (*snips.User, error) {
 	return user, nil
 }
 
+func (s *Sqlite) CreateAPIKey(ctx context.Context, key *snips.APIKey, maxKeys uint64) error {
+	const countQuery = `
+		SELECT COUNT(*)
+		FROM api_keys
+		WHERE user_id = ?
+	`
+
+	var count uint64
+	row := s.QueryRowContext(ctx, countQuery, key.UserID)
+	if err := row.Scan(&count); err != nil {
+		return err
+	}
+
+	if maxKeys > 0 && count >= maxKeys {
+		return ErrAPIKeyLimit
+	}
+
+	key.ID = id.New()
+	key.CreatedAt = time.Now().UTC()
+	key.UpdatedAt = time.Now().UTC()
+
+	const insertQuery = `
+		INSERT INTO api_keys (
+			id,
+			created_at,
+			updated_at,
+			name,
+			token_hash,
+			user_id,
+			last_used_at,
+			expires_at
+		) VALUES (?, ?, ?, ?, ?, ?, NULL, ?)
+	`
+
+	_, err := s.ExecContext(ctx, insertQuery,
+		key.ID,
+		key.CreatedAt,
+		key.UpdatedAt,
+		nullableName(key.Name),
+		key.TokenHash,
+		key.UserID,
+		key.ExpiresAt,
+	)
+
+	return err
+}
+
+func (s *Sqlite) FindAPIKeyByTokenHash(ctx context.Context, tokenHash string) (*snips.APIKey, error) {
+	const query = `
+		SELECT
+			id,
+			created_at,
+			updated_at,
+			name,
+			token_hash,
+			user_id,
+			last_used_at,
+			expires_at
+		FROM api_keys
+		WHERE token_hash = ?
+	`
+
+	key, err := scanAPIKey(s.QueryRowContext(ctx, query, tokenHash).Scan)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return key, nil
+}
+
+func (s *Sqlite) FindAPIKeysByUser(ctx context.Context, userID string) ([]*snips.APIKey, error) {
+	const query = `
+		SELECT
+			id,
+			created_at,
+			updated_at,
+			name,
+			token_hash,
+			user_id,
+			last_used_at,
+			expires_at
+		FROM api_keys
+		WHERE user_id = ?
+		ORDER BY created_at DESC, id DESC
+	`
+
+	rows, err := s.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	keys := []*snips.APIKey{}
+	for rows.Next() {
+		key, err := scanAPIKey(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+
+		keys = append(keys, key)
+	}
+
+	return keys, rows.Err()
+}
+
+func scanAPIKey(scan func(dest ...any) error) (*snips.APIKey, error) {
+	key := &snips.APIKey{}
+	name := sql.NullString{}
+	lastUsedAt := sql.NullTime{}
+	expiresAt := sql.NullTime{}
+
+	if err := scan(
+		&key.ID,
+		&key.CreatedAt,
+		&key.UpdatedAt,
+		&name,
+		&key.TokenHash,
+		&key.UserID,
+		&lastUsedAt,
+		&expiresAt,
+	); err != nil {
+		return nil, err
+	}
+
+	key.Name = name.String
+	if lastUsedAt.Valid {
+		key.LastUsedAt = &lastUsedAt.Time
+	}
+	if expiresAt.Valid {
+		key.ExpiresAt = &expiresAt.Time
+	}
+
+	return key, nil
+}
+
+func (s *Sqlite) DeleteAPIKey(ctx context.Context, id, userID string) (bool, error) {
+	const query = `
+		DELETE FROM api_keys
+		WHERE id = ? AND user_id = ?
+	`
+
+	result, err := s.ExecContext(ctx, query, id, userID)
+	if err != nil {
+		return false, err
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+
+	return affected > 0, nil
+}
+
+func (s *Sqlite) TouchAPIKey(ctx context.Context, id string) error {
+	const query = `
+		UPDATE api_keys
+		SET last_used_at = ?
+		WHERE id = ?
+	`
+
+	_, err := s.ExecContext(ctx, query, time.Now().UTC(), id)
+	return err
+}
+
 func (s *Sqlite) UpdateUser(ctx context.Context, user *snips.User) error {
 	const query = `
 		UPDATE users

--- a/internal/db/db_sqlite_test.go
+++ b/internal/db/db_sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -904,4 +905,152 @@ func (s *SqliteSuite) TestFindRevisionsByFileID_Pagination() {
 	s.Require().NoError(err)
 	s.Require().Len(page, 1)
 	s.Require().Equal(int64(1), page[0].Sequence)
+}
+
+func (s *SqliteSuite) TestCreateAPIKey() {
+	database := s.getTestDB(true)
+
+	token, hash, err := snips.NewAPIKeyToken()
+	s.Require().NoError(err)
+	s.Require().True(strings.HasPrefix(token, snips.APIKeyTokenPrefix))
+	s.Require().Equal(snips.HashAPIKeyToken(token), hash)
+
+	key := &snips.APIKey{
+		Name:      "ci",
+		TokenHash: hash,
+		UserID:    id.New(),
+	}
+
+	s.Require().NoError(database.CreateAPIKey(context.TODO(), key, 16))
+	s.Require().NotEmpty(key.ID)
+	s.Require().NotEmpty(key.CreatedAt)
+
+	found, err := database.FindAPIKeyByTokenHash(context.TODO(), hash)
+	s.Require().NoError(err)
+	s.Require().NotNil(found)
+	s.Require().Equal(key.ID, found.ID)
+	s.Require().Equal("ci", found.Name)
+	s.Require().Equal(key.UserID, found.UserID)
+	s.Require().Nil(found.LastUsedAt)
+}
+
+func (s *SqliteSuite) TestCreateAPIKey_Limit() {
+	database := s.getTestDB(true)
+	userID := id.New()
+
+	for i := 0; i < 2; i++ {
+		_, hash, err := snips.NewAPIKeyToken()
+		s.Require().NoError(err)
+		s.Require().NoError(database.CreateAPIKey(context.TODO(), &snips.APIKey{TokenHash: hash, UserID: userID}, 2))
+	}
+
+	_, hash, err := snips.NewAPIKeyToken()
+	s.Require().NoError(err)
+	err = database.CreateAPIKey(context.TODO(), &snips.APIKey{TokenHash: hash, UserID: userID}, 2)
+	s.Require().ErrorIs(err, db.ErrAPIKeyLimit)
+}
+
+func (s *SqliteSuite) TestFindAPIKeyByTokenHash_DoesNotExist() {
+	database := s.getTestDB(true)
+
+	key, err := database.FindAPIKeyByTokenHash(context.TODO(), snips.HashAPIKeyToken("nope"))
+	s.Require().NoError(err)
+	s.Require().Nil(key)
+}
+
+func (s *SqliteSuite) TestFindAPIKeysByUser() {
+	database := s.getTestDB(true)
+	userID := id.New()
+
+	ids := make([]string, 0, 3)
+	for i := 0; i < 3; i++ {
+		_, hash, err := snips.NewAPIKeyToken()
+		s.Require().NoError(err)
+		key := &snips.APIKey{TokenHash: hash, UserID: userID}
+		s.Require().NoError(database.CreateAPIKey(context.TODO(), key, 16))
+		ids = append(ids, key.ID)
+	}
+
+	// another user's key must never appear
+	_, hash, err := snips.NewAPIKeyToken()
+	s.Require().NoError(err)
+	s.Require().NoError(database.CreateAPIKey(context.TODO(), &snips.APIKey{TokenHash: hash, UserID: id.New()}, 16))
+
+	keys, err := database.FindAPIKeysByUser(context.TODO(), userID)
+	s.Require().NoError(err)
+	s.Require().Len(keys, 3)
+	for _, key := range keys {
+		s.Require().Contains(ids, key.ID)
+		s.Require().Equal(userID, key.UserID)
+	}
+}
+
+func (s *SqliteSuite) TestDeleteAPIKey() {
+	database := s.getTestDB(true)
+	userID := id.New()
+
+	_, hash, err := snips.NewAPIKeyToken()
+	s.Require().NoError(err)
+	key := &snips.APIKey{TokenHash: hash, UserID: userID}
+	s.Require().NoError(database.CreateAPIKey(context.TODO(), key, 16))
+
+	// another user cannot delete it
+	deleted, err := database.DeleteAPIKey(context.TODO(), key.ID, id.New())
+	s.Require().NoError(err)
+	s.Require().False(deleted)
+
+	deleted, err = database.DeleteAPIKey(context.TODO(), key.ID, userID)
+	s.Require().NoError(err)
+	s.Require().True(deleted)
+
+	found, err := database.FindAPIKeyByTokenHash(context.TODO(), hash)
+	s.Require().NoError(err)
+	s.Require().Nil(found)
+}
+
+func (s *SqliteSuite) TestTouchAPIKey() {
+	database := s.getTestDB(true)
+
+	_, hash, err := snips.NewAPIKeyToken()
+	s.Require().NoError(err)
+	key := &snips.APIKey{TokenHash: hash, UserID: id.New()}
+	s.Require().NoError(database.CreateAPIKey(context.TODO(), key, 16))
+
+	s.Require().NoError(database.TouchAPIKey(context.TODO(), key.ID))
+
+	found, err := database.FindAPIKeyByTokenHash(context.TODO(), hash)
+	s.Require().NoError(err)
+	s.Require().NotNil(found.LastUsedAt)
+}
+
+func (s *SqliteSuite) TestCreateAPIKey_WithExpiry() {
+	database := s.getTestDB(true)
+
+	_, hash, err := snips.NewAPIKeyToken()
+	s.Require().NoError(err)
+
+	expires := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	key := &snips.APIKey{
+		Name:      "expiring",
+		TokenHash: hash,
+		UserID:    id.New(),
+		ExpiresAt: &expires,
+	}
+	s.Require().NoError(database.CreateAPIKey(context.TODO(), key, 16))
+
+	found, err := database.FindAPIKeyByTokenHash(context.TODO(), hash)
+	s.Require().NoError(err)
+	s.Require().NotNil(found.ExpiresAt)
+	s.Require().Equal(expires, found.ExpiresAt.UTC())
+	s.Require().False(found.IsExpired())
+
+	past := time.Now().UTC().Add(-time.Hour)
+	_, hash, err = snips.NewAPIKeyToken()
+	s.Require().NoError(err)
+	expired := &snips.APIKey{Name: "stale", TokenHash: hash, UserID: id.New(), ExpiresAt: &past}
+	s.Require().NoError(database.CreateAPIKey(context.TODO(), expired, 16))
+
+	found, err = database.FindAPIKeyByTokenHash(context.TODO(), hash)
+	s.Require().NoError(err)
+	s.Require().True(found.IsExpired())
 }

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -3,6 +3,7 @@ package db
 import "errors"
 
 var (
-	ErrFileLimit = errors.New("file limit reached")
-	ErrNameTaken = errors.New("file already exists with that name")
+	ErrFileLimit   = errors.New("file limit reached")
+	ErrNameTaken   = errors.New("file already exists with that name")
+	ErrAPIKeyLimit = errors.New("api key limit reached")
 )

--- a/internal/db/migrations/00005_api_keys.sql
+++ b/internal/db/migrations/00005_api_keys.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE `api_keys` (
+	`id` text PRIMARY KEY,
+	`created_at` datetime,
+	`updated_at` datetime,
+	`name` text,
+	`token_hash` text NOT NULL,
+	`user_id` text NOT NULL,
+	`last_used_at` datetime,
+	`expires_at` datetime
+);
+
+CREATE UNIQUE INDEX `idx_api_keys_token_hash` ON `api_keys` (`token_hash`);
+
+CREATE INDEX `idx_api_keys_user_id` ON `api_keys` (`user_id`);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE `api_keys`;
+-- +goose StatementEnd

--- a/internal/snips/apikey.go
+++ b/internal/snips/apikey.go
@@ -3,7 +3,7 @@ package snips
 import (
 	"crypto/rand"
 	"crypto/sha512"
-	"encoding/base64"
+	"encoding/base32"
 	"encoding/hex"
 	"time"
 )
@@ -51,7 +51,7 @@ func NewAPIKeyToken() (token string, hash string, err error) {
 		return "", "", err
 	}
 
-	token = APIKeyTokenPrefix + base64.RawURLEncoding.EncodeToString(raw)
+	token = APIKeyTokenPrefix + base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(raw)
 	return token, HashAPIKeyToken(token), nil
 }
 

--- a/internal/snips/apikey.go
+++ b/internal/snips/apikey.go
@@ -1,0 +1,66 @@
+package snips
+
+import (
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"time"
+)
+
+const (
+	// APIKeyTokenPrefix prefixes every minted token so keys are recognizable
+	// (and grep-able) in configs and secret scanners.
+	APIKeyTokenPrefix = "snips_"
+
+	apiKeyTokenBytes = 32
+)
+
+// APIKey grants REST API access as a user. Only a hash of the token is
+// stored; the token itself is shown once at mint time.
+type APIKey struct {
+	ID         string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	Name       string
+	TokenHash  string
+	UserID     string
+	LastUsedAt *time.Time
+	ExpiresAt  *time.Time // nil = never expires
+}
+
+// IsExpired reports whether the key's optional expiry has passed. Expired
+// keys are rejected for authentication but kept (and listed) until removed.
+func (k *APIKey) IsExpired() bool {
+	return k.ExpiresAt != nil && time.Now().After(*k.ExpiresAt)
+}
+
+// DisplayName returns the key's name, falling back to its ID when unnamed.
+func (k *APIKey) DisplayName() string {
+	if k.Name != "" {
+		return k.Name
+	}
+	return k.ID
+}
+
+// NewAPIKeyToken mints a new random API token and returns it alongside the
+// hash to persist.
+func NewAPIKeyToken() (token string, hash string, err error) {
+	raw := make([]byte, apiKeyTokenBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", "", err
+	}
+
+	token = APIKeyTokenPrefix + base64.RawURLEncoding.EncodeToString(raw)
+	return token, HashAPIKeyToken(token), nil
+}
+
+// HashAPIKeyToken returns the hex-encoded SHA-384 digest of a token, the only
+// form in which tokens are stored.
+//
+// A fast hash is deliberate: unlike a password, a 256-bit random token can't
+// be brute forced, and lookups stay indexable.
+func HashAPIKeyToken(token string) string {
+	digest := sha512.Sum384([]byte(token))
+	return hex.EncodeToString(digest[:])
+}

--- a/internal/snips/apikey_test.go
+++ b/internal/snips/apikey_test.go
@@ -1,0 +1,16 @@
+package snips_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/robherley/snips.sh/internal/snips"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAPIKeyToken(t *testing.T) {
+	token, hash, err := snips.NewAPIKeyToken()
+	require.NoError(t, err)
+	require.Regexp(t, regexp.MustCompile(`^snips_[A-Z2-7]{52}$`), token)
+	require.Equal(t, snips.HashAPIKeyToken(token), hash)
+}

--- a/internal/ssh/apikey.go
+++ b/internal/ssh/apikey.go
@@ -1,0 +1,216 @@
+package ssh
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/armon/go-metrics"
+	"github.com/robherley/snips.sh/internal/db"
+	"github.com/robherley/snips.sh/internal/logger"
+	"github.com/robherley/snips.sh/internal/snips"
+	"github.com/robherley/snips.sh/internal/tui/styles"
+)
+
+// APIKey dispatches the `api-key <create|ls|rm>` command for managing REST
+// API keys.
+func (h *SessionHandler) APIKey(sesh *UserSession) {
+	args := sesh.Command()[1:]
+	if len(args) == 0 {
+		sesh.Error(ErrUnknownCommand, "Unknown command", "Usage: %s <create|ls|rm>", APIKeyCommand)
+		return
+	}
+
+	switch args[0] {
+	case "create":
+		h.CreateAPIKey(sesh, args[1:])
+	case "ls":
+		h.ListAPIKeys(sesh)
+	case "rm":
+		h.RemoveAPIKey(sesh, args[1:])
+	default:
+		sesh.Error(ErrUnknownCommand, "Unknown command", "Unknown subcommand %q, expected <create|ls|rm>", args[0])
+	}
+}
+
+func (h *SessionHandler) CreateAPIKey(sesh *UserSession, args []string) {
+	log := logger.From(sesh.Context())
+
+	flags := APIKeyCreateFlags{}
+	if err := flags.Parse(sesh.Stderr(), args); err != nil {
+		switch {
+		case errors.Is(err, flag.ErrHelp):
+		case errors.Is(err, ErrFlagRequired):
+			sesh.Error(err, "Unable to create api key", "A name is required, e.g.: api-key create -name ci")
+		default:
+			log.Warn("invalid user specified flags", "err", err)
+			sesh.Error(err, "Error parsing flag", "Error: %q", err.Error())
+		}
+		return
+	}
+
+	name, err := snips.NormalizeName(flags.Name)
+	if err != nil {
+		sesh.Error(err, "Unable to create api key", "Invalid name %q: %s", flags.Name, err.Error())
+		return
+	}
+
+	token, hash, err := snips.NewAPIKeyToken()
+	if err != nil {
+		sesh.Error(err, "Unable to create api key", "There was an error creating the api key. Please try again.")
+		return
+	}
+
+	key := &snips.APIKey{
+		Name:      name,
+		TokenHash: hash,
+		UserID:    sesh.UserID(),
+	}
+	if flags.TTL > 0 {
+		expires := time.Now().UTC().Add(flags.TTL)
+		key.ExpiresAt = &expires
+	}
+
+	if err := h.DB.CreateAPIKey(sesh.Context(), key, h.Config.Limits.APIKeysPerUser); err != nil {
+		if errors.Is(err, db.ErrAPIKeyLimit) {
+			sesh.Error(err, "Unable to create api key", "You already have the maximum of %d api keys. Remove one with: api-key rm <id>", h.Config.Limits.APIKeysPerUser)
+			return
+		}
+		sesh.Error(err, "Unable to create api key", "There was an error creating the api key. Please try again.")
+		return
+	}
+
+	metrics.IncrCounter([]string{"apikey", "create"}, 1)
+	log.Info("api key created", "api_key_id", key.ID, "user_id", key.UserID)
+
+	noti := Notification{
+		Color: styles.Colors.Green,
+		Title: "API Key Created 🔑",
+		WithStyle: func(s *lipgloss.Style) {
+			s.MarginTop(1)
+		},
+	}
+	created := styles.C(styles.Colors.White, key.DisplayName())
+	if key.ExpiresAt != nil {
+		created += "\nexpires: " + styles.C(styles.Colors.Yellow, key.ExpiresAt.Format(time.RFC3339))
+	}
+	noti.Messagef("%s", created)
+	noti.Render(sesh)
+
+	noti = Notification{
+		Color:   styles.Colors.Blue,
+		Title:   "Token 🔐",
+		Message: styles.C(styles.Colors.Yellow, token),
+		WithStyle: func(s *lipgloss.Style) {
+			s.MarginTop(1)
+		},
+	}
+	noti.Render(sesh)
+
+	noti = Notification{
+		Color:   styles.Colors.Red,
+		Title:   "Heads Up ⚠️",
+		Message: "Save this token now, it will not be shown again.\nUse it with: " + styles.C(styles.Colors.Blue, fmt.Sprintf("curl -H %q %s/api/v1/user", "Authorization: Bearer <token>", strings.TrimSuffix(h.Config.HTTP.External.String(), "/"))),
+		WithStyle: func(s *lipgloss.Style) {
+			s.MarginTop(1)
+		},
+	}
+	noti.Render(sesh)
+}
+
+func (h *SessionHandler) ListAPIKeys(sesh *UserSession) {
+	keys, err := h.DB.FindAPIKeysByUser(sesh.Context(), sesh.UserID())
+	if err != nil {
+		sesh.Error(err, "Unable to list api keys", "There was an error listing your api keys. Please try again.")
+		return
+	}
+
+	if len(keys) == 0 {
+		noti := Notification{
+			Color:   styles.Colors.Yellow,
+			Title:   "No API Keys ℹ️",
+			Message: "Create one with: api-key create -name <name>",
+			WithStyle: func(s *lipgloss.Style) {
+				s.MarginTop(1)
+			},
+		}
+		noti.Render(sesh)
+		return
+	}
+
+	var table strings.Builder
+	tabs := tabwriter.NewWriter(&table, 1, 0, 2, ' ', 0)
+	fmt.Fprintln(tabs, "KEY\tCREATED\tLAST USED\tEXPIRES")
+	for _, key := range keys {
+		lastUsed := "never"
+		if key.LastUsedAt != nil {
+			lastUsed = key.LastUsedAt.UTC().Format(time.RFC3339)
+		}
+		expires := "never"
+		switch {
+		case key.IsExpired():
+			expires = "expired"
+		case key.ExpiresAt != nil:
+			expires = key.ExpiresAt.UTC().Format(time.RFC3339)
+		}
+		fmt.Fprintf(tabs, "%s\t%s\t%s\t%s\n", key.DisplayName(), key.CreatedAt.UTC().Format(time.RFC3339), lastUsed, expires)
+	}
+	if err := tabs.Flush(); err != nil {
+		sesh.Error(err, "Unable to list api keys", "There was an error listing your api keys. Please try again.")
+		return
+	}
+
+	_, _ = fmt.Fprint(sesh, table.String())
+}
+
+func (h *SessionHandler) RemoveAPIKey(sesh *UserSession, args []string) {
+	log := logger.From(sesh.Context())
+
+	if len(args) == 0 || args[0] == "" {
+		sesh.Error(ErrAPIKeyIDRequired, "Unable to remove api key", "Provide an api key, e.g.: api-key rm <name> (list keys with: api-key ls)")
+		return
+	}
+
+	// keys are referenced by name when they have one, so accept either
+	keys, err := h.DB.FindAPIKeysByUser(sesh.Context(), sesh.UserID())
+	if err != nil {
+		sesh.Error(err, "Unable to remove api key", "There was an error removing api key: %q", args[0])
+		return
+	}
+
+	var target *snips.APIKey
+	for _, key := range keys {
+		if key.ID == args[0] || (key.Name != "" && strings.EqualFold(key.Name, args[0])) {
+			target = key
+			break
+		}
+	}
+
+	if target == nil {
+		sesh.Error(ErrAPIKeyNotFound, "Unable to remove api key", "API key not found: %q", args[0])
+		return
+	}
+
+	deleted, err := h.DB.DeleteAPIKey(sesh.Context(), target.ID, sesh.UserID())
+	if err != nil || !deleted {
+		sesh.Error(err, "Unable to remove api key", "There was an error removing api key: %q", args[0])
+		return
+	}
+
+	metrics.IncrCounter([]string{"apikey", "delete"}, 1)
+	log.Info("api key deleted", "api_key_id", target.ID, "user_id", sesh.UserID())
+
+	noti := Notification{
+		Color: styles.Colors.Green,
+		Title: "API Key Removed 🗑️",
+		WithStyle: func(s *lipgloss.Style) {
+			s.MarginTop(1)
+		},
+	}
+	noti.Messagef("Removed api key: %q", target.DisplayName())
+	noti.Render(sesh)
+}

--- a/internal/ssh/constants.go
+++ b/internal/ssh/constants.go
@@ -10,4 +10,6 @@ const (
 
 	FileRequestPrefix      = "f:"
 	NamedFileRequestPrefix = "n:"
+
+	APIKeyCommand = "api-key"
 )

--- a/internal/ssh/errors.go
+++ b/internal/ssh/errors.go
@@ -11,4 +11,6 @@ var (
 	ErrSignPublicFile    = errors.New("unable to sign public file")
 	ErrEmptyContent      = errors.New("empty content")
 	ErrNameRequired      = errors.New("name required")
+	ErrAPIKeyNotFound    = errors.New("api key not found")
+	ErrAPIKeyIDRequired  = errors.New("api key id required")
 )

--- a/internal/ssh/flags.go
+++ b/internal/ssh/flags.go
@@ -65,6 +65,9 @@ func (af *APIKeyCreateFlags) Parse(out io.Writer, args []string) error {
 	if af.Name == "" {
 		return fmt.Errorf("%w: -name", ErrFlagRequired)
 	}
+	if af.TTL < 0 {
+		return fmt.Errorf("%w: -ttl", ErrFlagParse)
+	}
 
 	return nil
 }

--- a/internal/ssh/flags.go
+++ b/internal/ssh/flags.go
@@ -44,6 +44,31 @@ func (uf *UploadFlags) Parse(out io.Writer, args []string) error {
 	return nil
 }
 
+type APIKeyCreateFlags struct {
+	*flag.FlagSet
+
+	Name string
+	TTL  time.Duration
+}
+
+func (af *APIKeyCreateFlags) Parse(out io.Writer, args []string) error {
+	af.FlagSet = flag.NewFlagSet("", flag.ContinueOnError)
+	af.SetOutput(out)
+
+	af.StringVar(&af.Name, "name", "", "human-readable name for the api key")
+	addDurationFlag(af.FlagSet, &af.TTL, "ttl", 0, "lifetime of the api key (optional, never expires when omitted)")
+
+	if err := af.FlagSet.Parse(args); err != nil {
+		return err
+	}
+
+	if af.Name == "" {
+		return fmt.Errorf("%w: -name", ErrFlagRequired)
+	}
+
+	return nil
+}
+
 type RenameFlags struct {
 	*flag.FlagSet
 

--- a/internal/ssh/flags_test.go
+++ b/internal/ssh/flags_test.go
@@ -96,6 +96,13 @@ func TestUploadFlags(t *testing.T) {
 	}
 }
 
+func TestAPIKeyCreateFlagsRejectsNegativeTTL(t *testing.T) {
+	var got ssh.APIKeyCreateFlags
+	err := got.Parse(io.Discard, []string{"-name", "ci", "-ttl", "-1h"})
+
+	assert.ErrorIs(t, err, ssh.ErrFlagParse)
+}
+
 func TestRenameFlags(t *testing.T) {
 	testcases := []struct {
 		name string

--- a/internal/ssh/handler.go
+++ b/internal/ssh/handler.go
@@ -47,6 +47,12 @@ func (h *SessionHandler) HandleFunc(_ ssh.Handler) ssh.Handler {
 			return
 		}
 
+		// user managing api keys
+		if args := userSesh.Command(); len(args) > 0 && args[0] == APIKeyCommand {
+			h.APIKey(userSesh)
+			return
+		}
+
 		// otherwise, it's a file upload
 		h.Upload(userSesh)
 	}

--- a/internal/tui/views/settings/apikeys.go
+++ b/internal/tui/views/settings/apikeys.go
@@ -1,0 +1,422 @@
+package settings
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/armon/go-metrics"
+	"github.com/robherley/snips.sh/internal/db"
+	"github.com/robherley/snips.sh/internal/logger"
+	"github.com/robherley/snips.sh/internal/snips"
+	"github.com/robherley/snips.sh/internal/timeutil"
+	"github.com/robherley/snips.sh/internal/tui/feedback"
+	"github.com/robherley/snips.sh/internal/tui/styles"
+)
+
+// apiKeysView is the api key management page: a list of the user's keys,
+// with a two-step (name, optional expiry) creation flow.
+type apiKeysView struct {
+	deps
+
+	list          []*snips.APIKey
+	cursor        int
+	naming        bool            // typing the name for a new key
+	expiring      bool            // typing the optional expiry for a new key
+	nameInput     textinput.Model // name input for a new key
+	ttlInput      textinput.Model // expiry input for a new key
+	pendingName   string          // name entered for the key being created
+	newToken      string          // token of the key just created, shown once
+	armedDeleteID string          // key id armed for deletion (press x twice)
+	feedback      feedback.Feedback
+}
+
+func newAPIKeysView(d deps) apiKeysView {
+	name := textinput.New()
+	name.CharLimit = snips.NameMaxLength
+	name.SetWidth(30)
+	name.Prompt = styles.BC(styles.Colors.Yellow, "> ")
+	name.Placeholder = "name"
+
+	ttl := textinput.New()
+	ttl.CharLimit = 32
+	ttl.SetWidth(30)
+	ttl.Prompt = styles.BC(styles.Colors.Yellow, "> ")
+	ttl.Placeholder = "expiry, e.g. 30d (optional)"
+
+	return apiKeysView{
+		deps:      d,
+		nameInput: name,
+		ttlInput:  ttl,
+	}
+}
+
+// enter loads the user's keys and resets the page state.
+func (m apiKeysView) enter() (apiKeysView, error) {
+	m.cursor = 0
+	m.naming = false
+	m.expiring = false
+	m.newToken = ""
+	m.armedDeleteID = ""
+	m.feedback = feedback.Feedback{}
+
+	if err := m.reload(&m); err != nil {
+		return m, err
+	}
+
+	return m, nil
+}
+
+// reload refreshes the key list from the database.
+func (m apiKeysView) reload(into *apiKeysView) error {
+	keys, err := m.db.FindAPIKeysByUser(m.ctx, m.user.ID)
+	if err != nil {
+		return fmt.Errorf("failed to load api keys: %w", err)
+	}
+
+	into.list = keys
+	if into.cursor >= len(keys) {
+		into.cursor = max(0, len(keys)-1)
+	}
+
+	return nil
+}
+
+func (m apiKeysView) update(msg tea.KeyPressMsg) (apiKeysView, result) {
+	if m.naming {
+		return m.updateNaming(msg)
+	}
+
+	if m.expiring {
+		return m.updateExpiring(msg)
+	}
+
+	// any key other than a second x disarms a pending deletion
+	if msg.String() != "x" {
+		m.armedDeleteID = ""
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "down", "j":
+		if m.cursor < len(m.list)-1 {
+			m.cursor++
+		}
+	case "n":
+		if uint64(len(m.list)) >= m.cfg.Limits.APIKeysPerUser {
+			m.feedback = feedback.Error(fmt.Sprintf("api key limit reached (%d)", m.cfg.Limits.APIKeysPerUser))
+			return m, result{}
+		}
+		m.naming = true
+		m.feedback = feedback.Feedback{}
+		m.nameInput.Reset()
+		return m, result{cmd: m.nameInput.Focus()}
+	case "x":
+		return m.deleteKey()
+	case "esc":
+		return m, result{back: true}
+	case "q":
+		// the view captures input on deeper pages, so quit needs handling here
+		return m, result{quit: true}
+	}
+	return m, result{}
+}
+
+// updateNaming handles the first creation step: a valid name moves on to the
+// optional expiry.
+func (m apiKeysView) updateNaming(msg tea.KeyPressMsg) (apiKeysView, result) {
+	switch msg.String() {
+	case "enter":
+		name := strings.TrimSpace(m.nameInput.Value())
+		if name == "" {
+			m.feedback = feedback.Error("a name is required")
+			return m, result{}
+		}
+		name, err := snips.NormalizeName(name)
+		if err != nil {
+			m.feedback = feedback.Error(err.Error())
+			return m, result{}
+		}
+		m.pendingName = name
+		m.naming = false
+		m.expiring = true
+		m.feedback = feedback.Feedback{}
+		m.ttlInput.Reset()
+		return m, result{cmd: m.ttlInput.Focus()}
+	case "esc":
+		m.naming = false
+		m.feedback = feedback.Feedback{}
+		return m, result{}
+	}
+
+	// everything else is typed into the name input
+	var cmd tea.Cmd
+	m.nameInput, cmd = m.nameInput.Update(msg)
+	return m, result{cmd: cmd}
+}
+
+// updateExpiring handles the second creation step: the optional expiry.
+func (m apiKeysView) updateExpiring(msg tea.KeyPressMsg) (apiKeysView, result) {
+	switch msg.String() {
+	case "enter":
+		return m.create()
+	case "esc":
+		m.expiring = false
+		m.feedback = feedback.Feedback{}
+		return m, result{}
+	}
+
+	// everything else is typed into the expiry input
+	var cmd tea.Cmd
+	m.ttlInput, cmd = m.ttlInput.Update(msg)
+	return m, result{cmd: cmd}
+}
+
+// create mints a key named in the previous step, showing the token once.
+func (m apiKeysView) create() (apiKeysView, result) {
+	var expiresAt *time.Time
+	if raw := strings.TrimSpace(m.ttlInput.Value()); raw != "" {
+		ttl, err := timeutil.ParseDuration(raw)
+		if err != nil || ttl <= 0 {
+			m.feedback = feedback.Error("invalid expiry: use a duration like 30d or 12h")
+			return m, result{}
+		}
+		expires := time.Now().UTC().Add(ttl)
+		expiresAt = &expires
+	}
+
+	token, hash, err := snips.NewAPIKeyToken()
+	if err != nil {
+		m.feedback = feedback.Error("failed to create api key: " + err.Error())
+		return m, result{}
+	}
+
+	key := &snips.APIKey{
+		Name:      m.pendingName,
+		TokenHash: hash,
+		UserID:    m.user.ID,
+		ExpiresAt: expiresAt,
+	}
+
+	if err := m.db.CreateAPIKey(m.ctx, key, m.cfg.Limits.APIKeysPerUser); err != nil {
+		if errors.Is(err, db.ErrAPIKeyLimit) {
+			m.feedback = feedback.Error(fmt.Sprintf("api key limit reached (%d)", m.cfg.Limits.APIKeysPerUser))
+		} else {
+			m.feedback = feedback.Error("failed to create api key: " + err.Error())
+		}
+		return m, result{}
+	}
+
+	metrics.IncrCounter([]string{"apikey", "create"}, 1)
+	logger.From(m.ctx).Info("api key created", "api_key_id", key.ID, "user_id", key.UserID)
+
+	m.expiring = false
+	m.newToken = token
+	m.feedback = feedback.Success("created api key " + key.DisplayName())
+
+	if err := m.reload(&m); err != nil {
+		m.feedback = feedback.Error(err.Error())
+	}
+	return m, result{}
+}
+
+// deleteKey removes the selected key, requiring x to be pressed twice.
+func (m apiKeysView) deleteKey() (apiKeysView, result) {
+	if len(m.list) == 0 {
+		return m, result{}
+	}
+
+	selected := m.list[m.cursor]
+	if m.armedDeleteID != selected.ID {
+		m.armedDeleteID = selected.ID
+		m.feedback = feedback.Error("press x again to delete " + selected.DisplayName())
+		return m, result{}
+	}
+
+	deleted, err := m.db.DeleteAPIKey(m.ctx, selected.ID, m.user.ID)
+	if err != nil || !deleted {
+		msg := "failed to delete api key"
+		if err != nil {
+			msg += ": " + err.Error()
+		}
+		m.feedback = feedback.Error(msg)
+		return m, result{}
+	}
+
+	metrics.IncrCounter([]string{"apikey", "delete"}, 1)
+	logger.From(m.ctx).Info("api key deleted", "api_key_id", selected.ID, "user_id", m.user.ID)
+
+	m.armedDeleteID = ""
+	m.newToken = ""
+	m.feedback = feedback.Success("deleted api key " + selected.DisplayName())
+
+	if err := m.reload(&m); err != nil {
+		m.feedback = feedback.Error(err.Error())
+	}
+	return m, result{}
+}
+
+// rows renders the key list, the creation inputs, and the one-time token
+// reveal after a mint.
+func (m apiKeysView) rows() []string {
+	mutedStyle := lipgloss.NewStyle().Foreground(styles.Colors.Muted)
+
+	rows := []string{
+		mutedStyle.Render(fmt.Sprintf("keys for the rest api (%d/%d)", len(m.list), m.cfg.Limits.APIKeysPerUser)),
+		"",
+	}
+
+	if len(m.list) == 0 {
+		rows = append(rows, mutedStyle.Render("no api keys yet — press n to create one"))
+	}
+
+	// pad the name column so the dates line up across rows
+	nameWidth := 0
+	for _, key := range m.list {
+		nameWidth = max(nameWidth, lipgloss.Width(key.DisplayName()))
+	}
+
+	for i, key := range m.list {
+		cursor := "  "
+		nameStyle := mutedStyle
+		if i == m.cursor && !m.naming && !m.expiring {
+			cursor = styles.BC(m.accent(), "→ ")
+			nameStyle = lipgloss.NewStyle().Foreground(styles.Colors.White).Bold(true)
+		}
+
+		lastUsed := "never used"
+		if key.LastUsedAt != nil {
+			lastUsed = "last used " + key.LastUsedAt.UTC().Format("2006-01-02")
+		}
+
+		row := cursor + nameStyle.Width(nameWidth).Render(key.DisplayName()) +
+			mutedStyle.Render(fmt.Sprintf("  ·  created %s  ·  %s", key.CreatedAt.UTC().Format("2006-01-02"), lastUsed))
+		switch {
+		case key.IsExpired():
+			row += mutedStyle.Render("  ·  ") + styles.C(styles.Colors.Red, "expired")
+		case key.ExpiresAt != nil:
+			row += mutedStyle.Render("  ·  expires " + key.ExpiresAt.UTC().Format("2006-01-02"))
+		}
+		if m.armedDeleteID == key.ID {
+			row += "  " + styles.C(styles.Colors.Red, "(press x again)")
+		}
+		rows = append(rows, row)
+	}
+
+	if m.naming {
+		rows = append(rows, "", m.nameInput.View())
+	}
+
+	if m.expiring {
+		rows = append(rows, "", mutedStyle.Render("name: ")+m.pendingName, m.ttlInput.View())
+	}
+
+	if m.newToken != "" {
+		rows = append(rows,
+			"",
+			styles.C(styles.Colors.Yellow, "copy your new api key now, it won't be shown again:"),
+			styles.C(styles.Colors.White, m.newToken),
+		)
+	}
+
+	if !m.feedback.Empty() {
+		rows = append(rows, "", m.feedback.View())
+	}
+
+	return rows
+}
+
+func (m apiKeysView) keys() help.KeyMap {
+	if m.naming || m.expiring {
+		return apiKeyNamingKeys
+	}
+	return apiKeysKeys
+}
+
+// apiKeysKeyMap is shown while navigating the api keys page.
+type apiKeysKeyMap struct {
+	Up     key.Binding
+	Down   key.Binding
+	New    key.Binding
+	Delete key.Binding
+	Esc    key.Binding
+	Quit   key.Binding
+}
+
+func (k apiKeysKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.New, k.Delete, k.Esc, k.Quit}
+}
+
+func (k apiKeysKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.Up, k.Down},
+		{k.New, k.Delete, k.Esc, k.Quit},
+	}
+}
+
+var apiKeysKeys = apiKeysKeyMap{
+	Up: key.NewBinding(
+		key.WithKeys("up", "k"),
+		key.WithHelp("↑/k", "move up"),
+	),
+	Down: key.NewBinding(
+		key.WithKeys("down", "j"),
+		key.WithHelp("↓/j", "move down"),
+	),
+	New: key.NewBinding(
+		key.WithKeys("n"),
+		key.WithHelp("n", "new key"),
+	),
+	Delete: key.NewBinding(
+		key.WithKeys("x"),
+		key.WithHelp("x", "delete key"),
+	),
+	Esc: key.NewBinding(
+		key.WithKeys("esc"),
+		key.WithHelp("esc", "back"),
+	),
+	Quit: key.NewBinding(
+		key.WithKeys("q", "ctrl+c"),
+		key.WithHelp("q", "quit"),
+	),
+}
+
+// apiKeyNamingKeyMap is shown while a creation input is focused; every other
+// key is typed into the input.
+type apiKeyNamingKeyMap struct {
+	Enter key.Binding
+	Esc   key.Binding
+	Quit  key.Binding
+}
+
+func (k apiKeyNamingKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Enter, k.Esc, k.Quit}
+}
+
+func (k apiKeyNamingKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{k.Enter, k.Esc, k.Quit}}
+}
+
+var apiKeyNamingKeys = apiKeyNamingKeyMap{
+	Enter: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("↵", "next"),
+	),
+	Esc: key.NewBinding(
+		key.WithKeys("esc"),
+		key.WithHelp("esc", "cancel"),
+	),
+	Quit: key.NewBinding(
+		key.WithKeys("ctrl+c"),
+		key.WithHelp("ctrl+c", "quit"),
+	),
+}

--- a/internal/tui/views/settings/apikeys.go
+++ b/internal/tui/views/settings/apikeys.go
@@ -221,7 +221,7 @@ func (m apiKeysView) create() (apiKeysView, result) {
 
 	m.expiring = false
 	m.newToken = token
-	m.feedback = feedback.Success("created api key " + key.DisplayName())
+	m.feedback = feedback.Success(fmt.Sprintf("created api key %q", key.DisplayName()))
 
 	if err := m.reload(&m); err != nil {
 		m.feedback = feedback.Error(err.Error())
@@ -257,7 +257,7 @@ func (m apiKeysView) deleteKey() (apiKeysView, result) {
 
 	m.armedDeleteID = ""
 	m.newToken = ""
-	m.feedback = feedback.Success("deleted api key " + selected.DisplayName())
+	m.feedback = feedback.Success(fmt.Sprintf("deleted api key %q", selected.DisplayName()))
 
 	if err := m.reload(&m); err != nil {
 		m.feedback = feedback.Error(err.Error())
@@ -270,10 +270,7 @@ func (m apiKeysView) deleteKey() (apiKeysView, result) {
 func (m apiKeysView) rows() []string {
 	mutedStyle := lipgloss.NewStyle().Foreground(styles.Colors.Muted)
 
-	rows := []string{
-		mutedStyle.Render(fmt.Sprintf("keys for the rest api (%d/%d)", len(m.list), m.cfg.Limits.APIKeysPerUser)),
-		"",
-	}
+	rows := []string{}
 
 	if len(m.list) == 0 {
 		rows = append(rows, mutedStyle.Render("no api keys yet — press n to create one"))

--- a/internal/tui/views/settings/settings.go
+++ b/internal/tui/views/settings/settings.go
@@ -23,6 +23,7 @@ type page int
 const (
 	rootPage page = iota
 	themePage
+	apiKeysPage
 	deletePage
 )
 
@@ -36,6 +37,7 @@ type entry struct {
 // entries lists the root menu; add new settings pages here.
 var entries = []entry{
 	{label: "theme color", page: themePage},
+	{label: "api keys", page: apiKeysPage},
 	{label: "delete all my data", page: deletePage, danger: true},
 }
 
@@ -72,8 +74,9 @@ type Settings struct {
 	cursor   int // selected entry on the root page
 	feedback feedback.Feedback
 
-	theme  themeView
-	delete deleteView
+	theme   themeView
+	apiKeys apiKeysView
+	delete  deleteView
 }
 
 func New(ctx context.Context, cfg *config.Config, width, height int, database db.DB, user *snips.User, fingerprint string) Settings {
@@ -90,6 +93,7 @@ func New(ctx context.Context, cfg *config.Config, width, height int, database db
 		width:       width,
 		height:      height,
 		theme:       newThemeView(d),
+		apiKeys:     newAPIKeysView(d),
 		delete:      newDeleteView(d),
 	}
 }
@@ -116,6 +120,8 @@ func (s Settings) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch s.page {
 		case themePage:
 			s.theme, res = s.theme.update(msg)
+		case apiKeysPage:
+			s.apiKeys, res = s.apiKeys.update(msg)
 		case deletePage:
 			s.delete, res = s.delete.update(msg)
 		default:
@@ -169,6 +175,8 @@ func (s Settings) open(p page) (tea.Model, tea.Cmd) {
 	switch p {
 	case themePage:
 		s.theme = s.theme.enter()
+	case apiKeysPage:
+		s.apiKeys, err = s.apiKeys.enter()
 	case deletePage:
 		s.delete, cmd, err = s.delete.enter()
 	}
@@ -189,6 +197,9 @@ func (s Settings) View() tea.View {
 	case themePage:
 		title = "settings / theme color"
 		rows = s.theme.rows()
+	case apiKeysPage:
+		title = "settings / api keys"
+		rows = s.apiKeys.rows()
 	case deletePage:
 		title = "settings / delete all my data"
 		rows = s.delete.rows()
@@ -246,6 +257,8 @@ func (s Settings) Keys() help.KeyMap {
 	switch s.page {
 	case themePage:
 		return themeKeys
+	case apiKeysPage:
+		return s.apiKeys.keys()
 	case deletePage:
 		return deleteKeys
 	default:

--- a/internal/web/constants.go
+++ b/internal/web/constants.go
@@ -4,6 +4,7 @@ type ContextKey string
 
 const (
 	RequestIDContextKey ContextKey = "request_id"
+	UserIDContextKey    ContextKey = "user_id"
 
 	RequestIDHeader = "X-Request-ID"
 )

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/robherley/snips.sh/internal/db"
 	"github.com/robherley/snips.sh/internal/id"
 	"github.com/robherley/snips.sh/internal/logger"
+	"github.com/robherley/snips.sh/internal/snips"
 )
 
 type Middleware func(next http.Handler) http.Handler
@@ -29,6 +31,51 @@ func WithMiddleware(handler http.Handler, middlewares ...Middleware) http.Handle
 		withMiddleware = middlewares[i](withMiddleware)
 	}
 	return withMiddleware
+}
+
+// UserID extracts the authenticated API user's ID from the request context,
+// placed there by WithAuthentication, reporting whether the request was
+// authenticated.
+func UserID(ctx context.Context) (string, bool) {
+	userID, ok := ctx.Value(UserIDContextKey).(string)
+	return userID, ok
+}
+
+// WithAuthentication authenticates a request with a bearer token.
+func WithAuthentication(database db.DB, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if !ok || !strings.HasPrefix(token, snips.APIKeyTokenPrefix) {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="snips.sh api"`)
+			http.Error(w, "missing or malformed api key", http.StatusUnauthorized)
+			return
+		}
+
+		key, err := database.FindAPIKeyByTokenHash(r.Context(), snips.HashAPIKeyToken(token))
+		if err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		if key == nil {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="snips.sh api"`)
+			http.Error(w, "unknown api key", http.StatusUnauthorized)
+			return
+		}
+
+		if key.IsExpired() {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="snips.sh api"`)
+			http.Error(w, "expired api key", http.StatusUnauthorized)
+			return
+		}
+
+		if err := database.TouchAPIKey(r.Context(), key.ID); err != nil {
+			logger.From(r.Context()).Warn("unable to touch api key", "err", err, "api_key_id", key.ID)
+		}
+
+		ctx := context.WithValue(r.Context(), UserIDContextKey, key.UserID)
+		next(w, r.WithContext(ctx))
+	}
 }
 
 // WithRequestID adds a unique request ID to the request context, and echoes

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -1,0 +1,192 @@
+package web_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/robherley/snips.sh/internal/db"
+	"github.com/robherley/snips.sh/internal/snips"
+	"github.com/robherley/snips.sh/internal/web"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithAuthentication(t *testing.T) {
+	newToken := func(t *testing.T) (string, string) {
+		token, hash, err := snips.NewAPIKeyToken()
+		require.NoError(t, err)
+		return token, hash
+	}
+
+	t.Run("rejects missing or malformed credentials", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			header string
+		}{
+			{name: "no authorization header", header: ""},
+			{name: "not a bearer token", header: "Basic dXNlcjpwYXNz"},
+			{name: "bearer token without snips prefix", header: "Bearer some-other-token"},
+			{name: "bearer prefix only", header: "Bearer "},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				// no DB expectations: malformed credentials must never hit the database
+				database := db.NewMockDB(t)
+
+				nextCalled := false
+				handler := web.WithAuthentication(database, func(w http.ResponseWriter, r *http.Request) {
+					nextCalled = true
+				})
+
+				req := httptest.NewRequest("GET", "/api/v1/user", nil)
+				if tc.header != "" {
+					req.Header.Set("Authorization", tc.header)
+				}
+
+				rec := httptest.NewRecorder()
+				handler(rec, req)
+
+				assert.False(t, nextCalled)
+				assert.Equal(t, http.StatusUnauthorized, rec.Code)
+				assert.Equal(t, `Bearer realm="snips.sh api"`, rec.Header().Get("WWW-Authenticate"))
+
+				assert.Equal(t, "missing or malformed api key\n", rec.Body.String())
+			})
+		}
+	})
+
+	t.Run("rejects unknown tokens", func(t *testing.T) {
+		token, hash := newToken(t)
+
+		database := db.NewMockDB(t)
+		database.EXPECT().FindAPIKeyByTokenHash(mock.Anything, hash).Return(nil, nil).Once()
+
+		nextCalled := false
+		handler := web.WithAuthentication(database, func(w http.ResponseWriter, r *http.Request) {
+			nextCalled = true
+		})
+
+		req := httptest.NewRequest("GET", "/api/v1/user", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		rec := httptest.NewRecorder()
+		handler(rec, req)
+
+		assert.False(t, nextCalled)
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		assert.Equal(t, `Bearer realm="snips.sh api"`, rec.Header().Get("WWW-Authenticate"))
+
+		assert.Equal(t, "unknown api key\n", rec.Body.String())
+	})
+
+	t.Run("fails closed on database errors", func(t *testing.T) {
+		token, hash := newToken(t)
+
+		database := db.NewMockDB(t)
+		database.EXPECT().FindAPIKeyByTokenHash(mock.Anything, hash).Return(nil, errors.New("boom")).Once()
+
+		nextCalled := false
+		handler := web.WithAuthentication(database, func(w http.ResponseWriter, r *http.Request) {
+			nextCalled = true
+		})
+
+		req := httptest.NewRequest("GET", "/api/v1/user", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		rec := httptest.NewRecorder()
+		handler(rec, req)
+
+		assert.False(t, nextCalled)
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		assert.Empty(t, rec.Header().Get("WWW-Authenticate"))
+	})
+
+	t.Run("accepts a valid token and stores the user id", func(t *testing.T) {
+		token, hash := newToken(t)
+		key := &snips.APIKey{ID: "key123", TokenHash: hash, UserID: "user123"}
+
+		database := db.NewMockDB(t)
+		database.EXPECT().FindAPIKeyByTokenHash(mock.Anything, hash).Return(key, nil).Once()
+		database.EXPECT().TouchAPIKey(mock.Anything, "key123").Return(nil).Once()
+
+		var (
+			gotUserID string
+			gotOK     bool
+		)
+		handler := web.WithAuthentication(database, func(w http.ResponseWriter, r *http.Request) {
+			gotUserID, gotOK = web.UserID(r.Context())
+		})
+
+		req := httptest.NewRequest("GET", "/api/v1/user", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		rec := httptest.NewRecorder()
+		handler(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.True(t, gotOK)
+		assert.Equal(t, "user123", gotUserID)
+	})
+
+	t.Run("proceeds when touching last_used_at fails", func(t *testing.T) {
+		token, hash := newToken(t)
+		key := &snips.APIKey{ID: "key123", TokenHash: hash, UserID: "user123"}
+
+		database := db.NewMockDB(t)
+		database.EXPECT().FindAPIKeyByTokenHash(mock.Anything, hash).Return(key, nil).Once()
+		database.EXPECT().TouchAPIKey(mock.Anything, "key123").Return(errors.New("boom")).Once()
+
+		nextCalled := false
+		handler := web.WithAuthentication(database, func(w http.ResponseWriter, r *http.Request) {
+			nextCalled = true
+		})
+
+		req := httptest.NewRequest("GET", "/api/v1/user", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		rec := httptest.NewRecorder()
+		handler(rec, req)
+
+		assert.True(t, nextCalled)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+}
+
+func TestUserID(t *testing.T) {
+	// unauthenticated contexts report !ok rather than panicking
+	req := httptest.NewRequest("GET", "/", nil)
+	userID, ok := web.UserID(req.Context())
+	assert.False(t, ok)
+	assert.Empty(t, userID)
+}
+
+func TestWithAuthentication_ExpiredKey(t *testing.T) {
+	token, hash, err := snips.NewAPIKeyToken()
+	require.NoError(t, err)
+
+	past := time.Now().UTC().Add(-time.Minute)
+	key := &snips.APIKey{ID: "key123", TokenHash: hash, UserID: "user123", ExpiresAt: &past}
+
+	database := db.NewMockDB(t)
+	database.EXPECT().FindAPIKeyByTokenHash(mock.Anything, hash).Return(key, nil).Once()
+
+	nextCalled := false
+	handler := web.WithAuthentication(database, func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	})
+
+	req := httptest.NewRequest("GET", "/api/v1/user", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Equal(t, "expired api key\n", rec.Body.String())
+}


### PR DESCRIPTION
In order to support a REST API (#291), we need the concept of API keys. These are tied to a user's identity and mint-able via the TUI or an SSH command.

The keys are 256-bit random tokens (shown once at create), and stored as as sha384 hashes. The tokens have a required name and optional expiry. Expired keys are rejected for auth but kept until explicitly removed.

https://github.com/user-attachments/assets/85705737-4f33-40c8-aa21-e9adfcb6a25b


https://github.com/user-attachments/assets/5007bd11-02e8-4533-8520-2944ed7d96d2

(the demos above predate the swap to base32 from base64)


