### PR TITLE
Restrict debug dumping of heap to loopback address only.  Add tests

### DIFF
--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -39,6 +40,23 @@ func WithMiddleware(handler http.Handler, middlewares ...Middleware) http.Handle
 func UserID(ctx context.Context) (string, bool) {
 	userID, ok := ctx.Value(UserIDContextKey).(string)
 	return userID, ok
+}
+
+// WithLocalhostOnly rejects requests that do not originate from a loopback address.
+func WithLocalhostOnly(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		ip := net.ParseIP(host)
+		if ip == nil || !ip.IsLoopback() {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		next(w, r)
+	}
 }
 
 // WithAuthentication authenticates a request with a bearer token.

--- a/internal/web/middleware_test.go
+++ b/internal/web/middleware_test.go
@@ -157,6 +157,37 @@ func TestWithAuthentication(t *testing.T) {
 	})
 }
 
+func TestWithLocalhostOnly(t *testing.T) {
+	next := func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+	handler := web.WithLocalhostOnly(next)
+
+	cases := []struct {
+		name       string
+		remoteAddr string
+		expected   int
+	}{
+		{name: "IPv4 loopback allowed", remoteAddr: "127.0.0.1:12345", expected: http.StatusOK},
+		{name: "IPv6 loopback allowed", remoteAddr: "[::1]:12345", expected: http.StatusOK},
+		{name: "public IPv4 forbidden", remoteAddr: "203.0.113.1:12345", expected: http.StatusForbidden},
+		{name: "private IPv4 forbidden", remoteAddr: "10.0.0.1:12345", expected: http.StatusForbidden},
+		{name: "malformed remote addr forbidden", remoteAddr: "not-an-addr", expected: http.StatusForbidden},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.RemoteAddr = tc.remoteAddr
+
+			rec := httptest.NewRecorder()
+			handler(rec, req)
+
+			assert.Equal(t, tc.expected, rec.Code)
+		})
+	}
+}
+
 func TestUserID(t *testing.T) {
 	// unauthenticated contexts report !ok rather than panicking
 	req := httptest.NewRequest("GET", "/", nil)

--- a/internal/web/service.go
+++ b/internal/web/service.go
@@ -32,7 +32,7 @@ func New(cfg *config.Config, database db.DB, assets Assets) (*Service, error) {
 	NewAPI(cfg, database).Register(mux)
 
 	if cfg.Debug {
-		mux.HandleFunc("/_debug/pprof/{profile}", ProfileHandler)
+		mux.HandleFunc("/_debug/pprof/{profile}", WithLocalhostOnly(ProfileHandler))
 	}
 
 	return &Service{

--- a/internal/web/service_test.go
+++ b/internal/web/service_test.go
@@ -405,6 +405,40 @@ func (suite *HTTPServiceSuite) TestFileMarkdownAccept() {
 	})
 }
 
+func (suite *HTTPServiceSuite) TestPprofEndpoints() {
+	suite.Run("pprof unavailable when debug is off", func() {
+		// Default config has Debug=false, so the route is not registered.
+		ts := httptest.NewServer(suite.service.Handler)
+		defer ts.Close()
+
+		req, err := http.NewRequest("GET", ts.URL+"/_debug/pprof/goroutine", nil)
+		suite.Require().NoError(err)
+
+		resp, err := ts.Client().Do(req)
+		suite.Require().NoError(err)
+		suite.Require().Equal(http.StatusNotFound, resp.StatusCode)
+	})
+
+	suite.Run("pprof accessible from localhost when debug is on", func() {
+		debugCfg := *suite.config
+		debugCfg.Debug = true
+
+		svc, err := web.New(&debugCfg, suite.mockDB, suite.assets)
+		suite.Require().NoError(err)
+
+		ts := httptest.NewServer(svc.Handler)
+		defer ts.Close()
+
+		// httptest connects from 127.0.0.1, so WithLocalhostOnly should pass.
+		req, err := http.NewRequest("GET", ts.URL+"/_debug/pprof/goroutine", nil)
+		suite.Require().NoError(err)
+
+		resp, err := ts.Client().Do(req)
+		suite.Require().NoError(err)
+		suite.Require().Equal(http.StatusOK, resp.StatusCode)
+	})
+}
+
 func (suite *HTTPServiceSuite) TestAssetCaching() {
 	ts := httptest.NewServer(suite.service.Handler)
 	defer ts.Close()


### PR DESCRIPTION
## Summary

- Adds WithLocalhostOnly middleware that inspects r.RemoteAddr, parses the host with net.SplitHostPort, and returns 403 Forbidden if the IP is not a loopback address (127.x.x.x / ::1)
- Wraps ProfileHandler with it before registration: WithLocalhostOnly(ProfileHandler)
- Pprof remains fully functional for operators connecting locally (e.g. ssh -L port forwarding)

## Tests

- TestWithLocalhostOnly — IPv4 loopback (200), IPv6 loopback (200), public IPv4 (403), private RFC1918 IPv4 (403), malformed RemoteAddr (403)
- TestPprofEndpoints — route absent when Debug=false (404); route reachable from loopback when Debug=true (200, since httptest connects via 127.0.0.1)

## Open Question

Could also just add a comment and warning, if remote dumping of heap is what was originally intended.